### PR TITLE
improve error msg for testBug421303_StreamProcessingDeadlock #5

### DIFF
--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTests.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTests.java
@@ -32,6 +32,8 @@ import java.util.Queue;
 import java.util.Random;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
 import org.eclipse.core.runtime.ILogListener;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -126,7 +128,7 @@ public class IOConsoleTests extends AbstractDebugTest {
 				throw new AssertionError("Test triggered errors in IOConsole", status.getException());
 			}
 		});
-		assertTrue("Test triggered errors in IOConsole: " + loggedErrors.stream().toString(), loggedErrors.isEmpty());
+		assertTrue("Test triggered errors in IOConsole: " + loggedErrors.stream().map(IStatus::toString).collect(Collectors.joining(", ")), loggedErrors.isEmpty());
 	}
 
 	/**


### PR DESCRIPTION
java.lang.AssertionError: Test triggered errors in IOConsole: Status ERROR: org.eclipse.debug.tests code=0 [testBug421303_StreamProcessingDeadlock] Some job is still running or waiting to run: 
'Animation start(41)'/org.eclipse.ui.internal.progress.TaskBarProgressManager$1
thread info: "Worker-11" prio=5 Id=64 TIMED_WAITING on org.eclipse.core.internal.jobs.WorkerPool@7910e307
	at java.base@11.0.10/java.lang.Object.wait(Native Method)
	-  waiting on org.eclipse.core.internal.jobs.WorkerPool@7910e307
	at org.eclipse.core.internal.jobs.WorkerPool.sleep(WorkerPool.java:200)
	at org.eclipse.core.internal.jobs.WorkerPool.startJob(WorkerPool.java:242)
	at org.eclipse.core.internal.jobs.Worker.run(Worker.java:58)


instead of
java.lang.AssertionError: Test triggered errors in IOConsole: java.util.stream.ReferencePipeline$Head@7269674d
