### PR TITLE
fix testBug421303_StreamProcessingDeadlock failure on Windows #5

### DIFF
--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestUtil.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestUtil.java
@@ -219,6 +219,7 @@ public class TestUtil {
 				// only uninteresting jobs running
 				break;
 			}
+			jobs.forEach(Job::wakeUp);
 
 			if (!Collections.disjoint(runningJobs, jobs)) {
 				// There is a job which runs already quite some time, don't wait for it to avoid test timeouts
@@ -231,11 +232,7 @@ public class TestUtil {
 				return true;
 			}
 			processUIEvents();
-			try {
-				Thread.sleep(10);
-			} catch (InterruptedException e) {
-				// Uninterruptable
-			}
+			Thread.yield();
 		}
 		runningJobs.clear();
 		return false;
@@ -245,7 +242,7 @@ public class TestUtil {
 
 	private static void dumpRunningOrWaitingJobs(String owner, List<Job> jobs) {
 		String message = "Some job is still running or waiting to run: " + dumpRunningOrWaitingJobs(jobs);
-		log(IStatus.ERROR, owner, message);
+		log(IStatus.ERROR, owner, message, new RuntimeException(message));
 	}
 
 	private static String dumpRunningOrWaitingJobs(List<Job> jobs) {

--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
@@ -25,7 +25,6 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.tests.TestUtil;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
@@ -694,19 +693,7 @@ public final class IOConsoleTestUtil {
 	 * @return this {@link IOConsoleTestUtil} to chain methods
 	 */
 	public IOConsoleTestUtil waitForScheduledJobs() {
-		boolean jobSleeping = false;
-		for (int i = 0; i < 5 && !jobSleeping; i++) {
-			final boolean jobPending = TestUtil.waitForJobs(name, 25, 2000);
-			if (!jobPending) {
-				jobSleeping = false;
-				for (Job job : TestUtil.getRunningOrWaitingJobs(null)) {
-					if (job.getState() == Job.SLEEPING) {
-						jobSleeping = true;
-						break;
-					}
-				}
-			}
-		}
+		TestUtil.waitForJobs(name, 25, 5 * 2000);
 		return this;
 	}
 


### PR DESCRIPTION
wait 10 sec instead of 5 times 2sec. The logged error after 3sec was
reported on teardown() even when 10sec have not yet passed.