### PR TITLE
WIP: POM and product version changes for 4.25 release

### DIFF
--- a/org.eclipse.debug.examples.memory/pom.xml
+++ b/org.eclipse.debug.examples.memory/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.debug</artifactId>
     <groupId>eclipse.platform.debug</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.debug</groupId>
   <artifactId>org.eclipse.debug.examples.memory</artifactId>

--- a/org.eclipse.debug.examples.mixedmode/pom.xml
+++ b/org.eclipse.debug.examples.mixedmode/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.debug</artifactId>
     <groupId>eclipse.platform.debug</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.debug</groupId>
   <artifactId>org.eclipse.debug.examples.mixedmode</artifactId>

--- a/org.eclipse.debug.tests/pom.xml
+++ b/org.eclipse.debug.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.debug</artifactId>
     <groupId>eclipse.platform.debug</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.debug</groupId>
   <artifactId>org.eclipse.debug.tests</artifactId>

--- a/org.eclipse.debug.ui.launchview.tests/pom.xml
+++ b/org.eclipse.debug.ui.launchview.tests/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.debug</artifactId>
     <groupId>eclipse.platform.debug</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.debug</groupId>
   <artifactId>org.eclipse.debug.ui.launchview.tests</artifactId>

--- a/org.eclipse.debug.ui.launchview/pom.xml
+++ b/org.eclipse.debug.ui.launchview/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <artifactId>eclipse.platform.debug</artifactId>
     <groupId>eclipse.platform.debug</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   
    <properties>

--- a/org.eclipse.debug.ui/pom.xml
+++ b/org.eclipse.debug.ui/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.debug</artifactId>
     <groupId>eclipse.platform.debug</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.debug</groupId>
   <artifactId>org.eclipse.debug.ui</artifactId>

--- a/org.eclipse.unittest.ui/pom.xml
+++ b/org.eclipse.unittest.ui/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <artifactId>eclipse.platform.debug</artifactId>
     <groupId>eclipse.platform.debug</groupId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
   </parent>
   <groupId>org.eclipse.debug</groupId>
   <artifactId>org.eclipse.unittest.ui</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.24.0-SNAPSHOT</version>
+    <version>4.25.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
Tracked in [eclipse.platform.releng.aggregator#290](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/290) and [eclipse.platform.releng.aggregator#291](https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/291)

Need to wait to merge until after 4.24 Release