### PR TITLE
Add "Show in Project Explorer" to Debug perspective

### DIFF
--- a/org.eclipse.debug.ui/plugin.xml
+++ b/org.eclipse.debug.ui/plugin.xml
@@ -65,6 +65,9 @@
 	     <viewShortcut
       		   id="org.eclipse.pde.runtime.LogView">
    		 </viewShortcut>
+      <showInPart
+            id="org.eclipse.ui.navigator.ProjectExplorer">
+      </showInPart>
       </perspectiveExtension>
    </extension>
    <extension


### PR DESCRIPTION
Looks like this after the change, when using "Open resource" in Debug perspective:
![image](https://user-images.githubusercontent.com/406876/173180034-6259063f-37ce-427c-98bf-82c7043e0175.png)

If you want to test locally, remember to reset the perspective of your test runtime to see the effect.
