### PR TITLE
Cosmetics to SerialExecutorTest.

### DIFF
--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/SerialExecutorTest.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/breakpoint/SerialExecutorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- *  Copyright (c) 2021 Joerg Kubitz and others.
+ *  Copyright (c) 2021, 2022 Joerg Kubitz and others.
  *
  *  This program and the accompanying materials
  *  are made available under the terms of the Eclipse Public License 2.0
@@ -38,14 +38,14 @@ public class SerialExecutorTest extends AbstractDebugTest {
 	public void testSimpleExecution() throws InterruptedException {
 		SerialExecutor serialExecutor = new SerialExecutor("test", this);
 		AtomicInteger executions = new AtomicInteger(0);
-		serialExecutor.schedule(() -> executions.incrementAndGet());
+		serialExecutor.schedule(executions::incrementAndGet);
 		Job.getJobManager().join(this, null);
 		assertEquals(1, executions.get());
-		serialExecutor.schedule(() -> executions.incrementAndGet());
+		serialExecutor.schedule(executions::incrementAndGet);
 		Job.getJobManager().join(this, null);
 		assertEquals(2, executions.get());
-		serialExecutor.schedule(() -> executions.incrementAndGet());
-		serialExecutor.schedule(() -> executions.incrementAndGet());
+		serialExecutor.schedule(executions::incrementAndGet);
+		serialExecutor.schedule(executions::incrementAndGet);
 		Job.getJobManager().join(this, null);
 		assertEquals(4, executions.get());
 	}
@@ -126,7 +126,7 @@ public class SerialExecutorTest extends AbstractDebugTest {
 		AtomicInteger executions = new AtomicInteger();
 		int RUNS = 200;
 		for (int i = 0; i < RUNS; i++) {
-			serialExecutor.schedule(() -> executions.incrementAndGet());
+			serialExecutor.schedule(executions::incrementAndGet);
 		}
 		Job.getJobManager().join(this, null);
 		Job[] jobs = Job.getJobManager().find(this);


### PR DESCRIPTION
Haven't noticed this test failure till now, looked at the code but no
idea.
Failure is:
```
expected:<4> but was:<3>

java.lang.AssertionError: expected:<4> but was:<3>
at org.junit.Assert.fail(Assert.java:89)
at org.junit.Assert.failNotEquals(Assert.java:835)
at org.junit.Assert.assertEquals(Assert.java:647)
at org.junit.Assert.assertEquals(Assert.java:633)
at org.eclipse.debug.tests.breakpoint.SerialExecutorTest.testSimpleExecution(SerialExecutorTest.java:50)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native
Method)
at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
at java.base/java.lang.reflect.Method.invoke(Method.java:568)
```

Do some minimal modernization of the test while at it.