### PR TITLE
NPE in RunDebugPropertiesPage (fixes #33)

### DIFF
--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/RunDebugPropertiesPage.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/preferences/RunDebugPropertiesPage.java
@@ -21,7 +21,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.Adapters;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.debug.core.DebugPlugin;
@@ -284,7 +286,10 @@ public class RunDebugPropertiesPage extends PropertyPage {
 		if (element instanceof IResource) {
 			resource = (IResource) element;
 		} else if (element != null) {
-			resource = element.getAdapter(IResource.class);
+			resource = Adapters.adapt(element, IResource.class);
+		}
+		if (resource == null && element != null) {
+			return Adapters.adapt(element, IProject.class);
 		}
 		return resource;
 	}


### PR DESCRIPTION
The plugin.xml enables this page for objects that adapt to IResource or
to IProject. The Java code however completely misses the part for
adapting to IProject. Therefore each object that adapts to IProject but
not IResource would cause an NPE until now.