### PR TITLE
fix findPosition to return only all overlapping positions

### DIFF
--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/TextConsoleViewerTest.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/TextConsoleViewerTest.java
@@ -20,8 +20,8 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.function.Consumer;
 
 import org.eclipse.debug.tests.AbstractDebugTest;
 import org.eclipse.jface.text.Position;
@@ -310,10 +310,10 @@ public class TextConsoleViewerTest extends AbstractDebugTest {
 	 * Test that findPosition returns only all overlapping positions
 	 */
 	@Test
-	public void testFindPosition() throws Throwable {
+	public void testVisitOverlappingPositions() throws Throwable {
 
 		try {
-			final Method method = TextConsoleViewer.class.getDeclaredMethod("findPosition", int.class, int.class, Position[].class);
+			final Method method = TextConsoleViewer.class.getDeclaredMethod("visitOverlappingPositions", int.class, int.class, Position[].class, Consumer.class);
 			method.setAccessible(true);
 			assertTrue("Required method <" + method + "> is not static.", Modifier.isStatic(method.getModifiers()));
 
@@ -324,8 +324,15 @@ public class TextConsoleViewerTest extends AbstractDebugTest {
 
 			var length = 10;
 			for (int i = 0; i < 100; ++i) {
-				var result = (Position[]) method.invoke(null, i, length, positions);
-				var overlappingPositions = result != null ? Arrays.asList(result) : new ArrayList<>();
+				var overlappingPositions = new ArrayList<>();
+
+				method.invoke(null, i, length, positions, new Consumer<Position>() {
+					@Override
+					public void accept(Position t)
+					 {
+						 overlappingPositions.add(t);
+					 }
+				});
 
 				for (var p : positions) {
 					assertTrue(p.overlapsWith(i, length) == overlappingPositions.contains(p));

--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/TextConsoleViewerTest.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/TextConsoleViewerTest.java
@@ -318,7 +318,7 @@ public class TextConsoleViewerTest extends AbstractDebugTest {
 			assertTrue("Required method <" + method + "> is not static.", Modifier.isStatic(method.getModifiers()));
 
 			Position[] positions = {
-					new Position(12, 5), new Position(17, 3),
+					new Position(12, 5), new Position(17, 12),
 					new Position(30, 10), new Position(41, 9),
 					new Position(60, 20) };
 

--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/TextConsoleViewerTest.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/TextConsoleViewerTest.java
@@ -20,9 +20,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.debug.tests.AbstractDebugTest;
+import org.eclipse.jface.text.Position;
 import org.eclipse.swt.custom.StyleRange;
 import org.eclipse.swt.graphics.Color;
 import org.eclipse.ui.console.TextConsoleViewer;
@@ -301,6 +303,44 @@ public class TextConsoleViewerTest extends AbstractDebugTest {
 			assertTrue("Styles overlap or not sorted.", lastEnd <= s.start);
 			assertTrue("Empty style.", s.length > 0);
 			lastEnd = s.start + s.length;
+		}
+	}
+
+	/**
+	 * Test that findPosition returns only all overlapping positions
+	 */
+	@Test
+	public void testFindPosition() throws Throwable {
+
+		try {
+			final Method method = TextConsoleViewer.class.getDeclaredMethod("findPosition", int.class, int.class, Position[].class);
+			method.setAccessible(true);
+			assertTrue("Required method <" + method + "> is not static.", Modifier.isStatic(method.getModifiers()));
+
+			Position[] positions = {
+					new Position(12, 5), new Position(17, 3),
+					new Position(30, 10), new Position(41, 9),
+					new Position(60, 20) };
+
+			var length = 10;
+			for (int i = 0; i < 100; ++i) {
+				var result = (Position[]) method.invoke(null, i, length, positions);
+				var overlappingPositions = result != null ? Arrays.asList(result) : new ArrayList<>();
+
+				for (var p : positions) {
+					assertTrue(p.overlapsWith(i, length) == overlappingPositions.contains(p));
+				}
+
+			}
+
+		} catch (InvocationTargetException e) {
+			if (e.getTargetException() != null) {
+				throw e.getTargetException();
+			}
+			throw e;
+		} catch (Exception e) {
+			// if this happened the method may have be renamed or moved
+			throw e;
 		}
 	}
 }

--- a/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsoleViewer.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsoleViewer.java
@@ -528,7 +528,7 @@ public class TextConsoleViewer extends SourceViewer implements LineStyleListener
 		var index = left - 1;
 		if (index >= 0) {
 			position = positions[index];
-			while (position.getOffset() + position.getLength() - 1 > offset) {
+			while (position.getOffset() + position.getLength() > offset) {
 				index--;
 				if (index < 0) {
 					break;

--- a/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleDocument.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ConsoleDocument.java
@@ -100,6 +100,11 @@ public class ConsoleDocument extends Document {
 		return super.getPositions(category);
 	}
 
+	@Override
+	public synchronized Position[] getPositions(String category, int offset, int length, boolean canStartBefore,
+			boolean canEndAfter) throws BadPositionCategoryException {
+		return super.getPositions(category, offset, length, canStartBefore, canEndAfter);
+	}
 	/** for debug only **/
 	@Override
 	public synchronized String toString() {


### PR DESCRIPTION
Add a test to check that TextConsoleViewer::findPosition returns only all overlapping positions.

Fix the findPosition method to be compliant.

The test failed with the old implementation. findPosition must be declared static to verify.