### PR TITLE
Add help context for the ANSI Preferences dialog

### DIFF
--- a/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/IConsoleHelpContextIds.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/IConsoleHelpContextIds.java
@@ -49,5 +49,6 @@ public interface IConsoleHelpContextIds {
 
 	// Preference pages
 	String CONSOLE_PREFERENCE_PAGE = PREFIX + "console_preference_page_context"; //$NON-NLS-1$
+	String CONSOLE_ANSI_PREFERENCE_PAGE = PREFIX + "console_ansi_preference_page_context"; //$NON-NLS-1$
 }
 

--- a/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ansi/preferences/AnsiConsolePreferencePage.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ansi/preferences/AnsiConsolePreferencePage.java
@@ -20,6 +20,7 @@ import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.console.ConsolePlugin;
 import org.eclipse.ui.handlers.IHandlerService;
+import org.eclipse.ui.internal.console.IConsoleHelpContextIds;
 import org.eclipse.ui.internal.console.ansi.AnsiMessages;
 import org.eclipse.ui.internal.console.ansi.commands.EnableDisableHandler;
 import org.eclipse.ui.internal.console.ansi.utils.AnsiConsoleColorPalette;
@@ -30,6 +31,13 @@ public class AnsiConsolePreferencePage extends FieldEditorPreferencePage impleme
 		super(GRID);
 		setPreferenceStore(ConsolePlugin.getDefault().getPreferenceStore());
 		setDescription(AnsiMessages.PreferencePage_Title);
+	}
+
+	@Override
+	public void createControl(Composite parent) {
+		super.createControl(parent);
+		PlatformUI.getWorkbench().getHelpSystem().setHelp(
+				getControl(), IConsoleHelpContextIds.CONSOLE_ANSI_PREFERENCE_PAGE);
 	}
 
 	@Override


### PR DESCRIPTION
The https://github.com/eclipse-platform/eclipse.platform.common/pull/60 adds a help page for the ANSI Support Preferences page:

And this PR adds the proper context IDs so that invoking the help from the preference dialog gets us to the right web page.

---

This is to address 
https://github.com/eclipse-platform/eclipse.platform.debug/issues/47#issuecomment-1206036042
