### PR TITLE
Remove org.eclipse.pde.ds.lib/annotations.jar from extra classpath

### DIFF
--- a/org.eclipse.debug.ui.launchview/build.properties
+++ b/org.eclipse.debug.ui.launchview/build.properties
@@ -8,4 +8,3 @@ bin.includes = META-INF/,\
                about.html
 source.. = src/
 src.includes = about.html
-jars.extra.classpath = platform:/plugin/org.eclipse.pde.ds.lib/annotations.jar


### PR DESCRIPTION
This is obsolete now