### PR TITLE
Don't use getActiveWorkbenchWindow() which can be null

### DIFF
--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPlugin.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPlugin.java
@@ -1252,7 +1252,7 @@ public class DebugUIPlugin extends AbstractUIPlugin implements ILaunchListener, 
 		job.setName(MessageFormat.format(DebugUIMessages.DebugUIPlugin_25, new Object[] {configuration.getName()}));
 
 		if (wait) {
-			progressService.showInDialog(workbench.getActiveWorkbenchWindow().getShell(), job);
+			progressService.showInDialog(getShell(), job);
 		}
 		job.schedule();
 	}


### PR DESCRIPTION
Fixes https://github.com/eclipse-platform/.github/issues/50