### PR TITLE
Fix Javadoc warnings and errors.

### DIFF
--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/PrototypeTab.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/PrototypeTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017,2018 Obeo and others.
+ * Copyright (c) 2017,2022 Obeo and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -74,9 +74,9 @@ import org.eclipse.ui.dialogs.ElementListSelectionDialog;
  * <p>
  * Clients may instantiate this class only if the associated launch
  * configuration type allows prototypes.
+ * </p>
  *
  * @see ILaunchConfigurationType#supportsPrototypes()
- *      </p>
  *
  * @since 3.13
  * @noextend This class is not intended to be subclassed by clients.

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/ExportBreakpointsOperation.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/ExportBreakpointsOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corporation and others.
+ * Copyright (c) 2005, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -46,7 +46,8 @@ import org.eclipse.ui.XMLMemento;
  * Exports breakpoints to a file or string buffer.
  * <p>
  * This class may be instantiated.
- * <p>
+ * </p>
+ *
  * @since 3.2
  * @noextend This class is not intended to be sub-classed by clients.
  */

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/ImportBreakpointsOperation.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/ImportBreakpointsOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2018 IBM Corporation and others.
+ * Copyright (c) 2005, 2022 IBM Corporation and others.
  *
  * This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
@@ -58,7 +58,8 @@ import org.eclipse.ui.XMLMemento;
  * Imports breakpoints from a file or string buffer into the workspace.
  * <p>
  * This class may be instantiated.
- * <p>
+ * </p>
+ *
  * @since 3.2
  * @noextend This class is not intended to be subclassed by clients.
  */


### PR DESCRIPTION
As found by Java 17 javadoc tool.
Needed by
eclipse-platform/eclipse.platform.releng.aggregator#482