### PR TITLE
Avoid creating Timer objects only used on resume

### DIFF
--- a/org.eclipse.debug.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.debug.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.ui; singleton:=true
-Bundle-Version: 3.17.0.qualifier
+Bundle-Version: 3.17.100.qualifier
 Bundle-Activator: org.eclipse.debug.internal.ui.DebugUIPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
This avoids creating Thread objects if not needed by proxy.
Additionally give Timer some simple name to see which proxy class
created timer.

See https://github.com/eclipse-platform/eclipse.platform/issues/538
