### PR TITLE
ANSI Support: store HTML format in the clipboard (#85)

### DIFF
--- a/org.eclipse.ui.console/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.console/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.ui.console; singleton:=true
-Bundle-Version: 3.11.300.qualifier
+Bundle-Version: 3.11.400.qualifier
 Bundle-Activator: org.eclipse.ui.console.ConsolePlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ansi/AnsiConsoleUtils.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ansi/AnsiConsoleUtils.java
@@ -14,6 +14,7 @@ import java.util.regex.Pattern;
 
 public class AnsiConsoleUtils {
 	public static final Pattern ESCAPE_SEQUENCE_REGEX_TXT = Pattern.compile("\u001b\\[[\\d;]*[A-HJKSTfimnsu]"); //$NON-NLS-1$
+	public static final Pattern ESCAPE_SEQUENCE_REGEX_HTML = Pattern.compile("<span[^>]*>\u001b\\[[\\d;]*[A-HJKSTfimnsu]</span>"); //$NON-NLS-1$
 	public static final Pattern ESCAPE_SEQUENCE_REGEX_RTF = Pattern.compile("\\{\\\\cf\\d+[^}]* \u001b\\[[\\d;]*[A-HJKSTfimnsu][^}]*\\}"); //$NON-NLS-1$
 	// These two are used to replace \chshdng#1\chcbpat#2 with \chshdng#1\chcbpat#2\cb#2
 	public static final Pattern ESCAPE_SEQUENCE_REGEX_RTF_FIX_SRC = Pattern.compile("\\\\chshdng\\d+\\\\chcbpat(\\d+)"); //$NON-NLS-1$

--- a/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ansi/messages.properties
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/ansi/messages.properties
@@ -5,7 +5,7 @@ PreferencePage_PluginEnabled=Enable ANSI support
 PreferencePage_Option_WindowsMapping=Use &Windows color mapping (bold => intense, italic => reverse)
 PreferencePage_Option_ShowEscapes=&Show the escape sequences
 PreferencePage_Option_HonorStderr=&Try using the standard error color setting for stderr output
-PreferencePage_Option_RtfInClipboard=Put &RTF in Clipboard. You will be able to paste styled text in some applications.
+PreferencePage_Option_RtfInClipboard=Put &HTML and RTF in Clipboard. You will be able to paste styled text in some applications.
 PreferencePage_Option_ColorPaletteSectionTitle=&Color palette:
 PreferencePage_Option_ColorPaletteVGA=Standard VGA colors
 PreferencePage_Option_ColorPaletteWinXP=Windows XP command prompt


### PR DESCRIPTION
Fixed.

See attached the results of the paste in MS Word.
I've changed the document to blue to make the white text from Eclipse more visible.
And I used the Eclipse dark theme to check that the background works properly in the clipboard.

![image](https://user-images.githubusercontent.com/1307726/194037250-55d687d3-6a70-487b-a192-03a70aae0844.png)
