### PR TITLE
[Build] Fix Tycho-pomless properties by moving them to build.properties

### DIFF
--- a/org.eclipse.debug.ui.launchview.tests/build.properties
+++ b/org.eclipse.debug.ui.launchview.tests/build.properties
@@ -20,3 +20,7 @@ bin.includes = META-INF/,\
                plugin.properties,\
                plugin.xml
 
+# Maven/Tycho pom model adjustments
+pom.model.property.testClass = org.eclipse.debug.ui.launchview.tests.AutomatedSuite
+pom.model.property.tycho.surefire.useUIHarness = true
+pom.model.property.tycho.surefire.useUIThread = true

--- a/org.eclipse.debug.ui.launchview.tests/plugin.properties
+++ b/org.eclipse.debug.ui.launchview.tests/plugin.properties
@@ -15,7 +15,3 @@
 pluginName=Debug UI (LaunchView) Test Plugin
 providerName=Eclipse.org
 
-# Maven/Tycho pom model adjustments
-pom.model.property.testClass = org.eclipse.debug.ui.launchview.tests.AutomatedSuite
-pom.model.property.tycho.surefire.useUIHarness = true
-pom.model.property.tycho.surefire.useUIThread = true


### PR DESCRIPTION
They were erroneously added to the plugin.properties instead of the build.properties.

FYI @iloveeclipse, @akurtakov