### PR TITLE
Remove unused keys from ExternalToolsUIMessages #102

### DIFF
--- a/org.eclipse.ui.externaltools/External Tools Base/org/eclipse/ui/externaltools/internal/ui/ExternalToolsUIMessages.java
+++ b/org.eclipse.ui.externaltools/External Tools Base/org/eclipse/ui/externaltools/internal/ui/ExternalToolsUIMessages.java
@@ -55,10 +55,6 @@ public class ExternalToolsUIMessages extends NLS {
 	public static String FileSelectionDialog_Ok_2;
 	public static String FileSelectionDialog_Cancel_3;
 
-	public static String ExternalToolsPreferencePage_External_tool_project_builders_migration_2;
-	public static String ExternalToolsPreferencePage_Prompt_before_migrating_3;
-	public static String ExternalToolsPreferencePage_1;
-
 	public static String EditCommandDialog_0;
 	public static String EditCommandDialog_1;
 	public static String EditCommandDialog_2;

--- a/org.eclipse.ui.externaltools/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.externaltools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.externaltools; singleton:=true
-Bundle-Version: 3.5.200.qualifier
+Bundle-Version: 3.5.300.qualifier
 Bundle-Activator: org.eclipse.ui.externaltools.internal.model.ExternalToolsPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin


### PR DESCRIPTION
Removed three unused keys that starts from
`ExternalToolsPreferencePage_`

Signed-off-by: Alexander Fedorov <alexander.fedorov@arsysop.ru>