### PR TITLE
Use current shell for nested modal dialogs, fixes #110

### DIFF
--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/ExportLaunchConfigurationAction.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/ExportLaunchConfigurationAction.java
@@ -47,7 +47,7 @@ public class ExportLaunchConfigurationAction extends AbstractLaunchConfiguration
 			wizard = new ExportLaunchConfigurationsWizard(selection);
 		}
 		wizard.init(PlatformUI.getWorkbench(), null);
-		WizardDialog dialog = new WizardDialog(DebugUIPlugin.getShell(), wizard);
+		WizardDialog dialog = new WizardDialog(getShell(), wizard);
 		dialog.open();
 	}
 


### PR DESCRIPTION
Don't take the workbench window for opening new dialogs. This leads to blocked UI if a modal dialog gets triggered from another modal dialog. Since the action itself knows its shell, that one is a better solution.