### PR TITLE
Process Console command line history

### DIFF
--- a/org.eclipse.debug.tests/plugin.xml
+++ b/org.eclipse.debug.tests/plugin.xml
@@ -163,4 +163,11 @@
          priority="-1"
          class="org.eclipse.debug.tests.ui.TestVariableValueEditor3"/>
    </extension>
+   <extension
+         point="org.eclipse.ui.console.consolePageParticipants">
+      <consolePageParticipant
+            class="org.eclipse.debug.tests.TestsConsolePageParticipant"
+            id="org.eclipse.debug.tests.consolePageParticipant">
+      </consolePageParticipant>
+   </extension>
 </plugin>

--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestsConsolePageParticipant.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/TestsConsolePageParticipant.java
@@ -1,0 +1,39 @@
+package org.eclipse.debug.tests;
+
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IConsolePageParticipant;
+import org.eclipse.ui.console.IIOConsolePage;
+import org.eclipse.ui.console.TextConsole;
+import org.eclipse.ui.part.IPageBookViewPage;
+
+public class TestsConsolePageParticipant implements IConsolePageParticipant {
+
+	@Override
+	public <T> T getAdapter(Class<T> adapter) {
+		return null;
+	}
+
+	@Override
+	public void init(IPageBookViewPage page, IConsole console) {
+		if (console instanceof TextConsole textConsole) {
+			Object history = textConsole.getAttribute("history");
+			if (history != null && history.equals("true")) {
+				if (page instanceof IIOConsolePage iocPage) {
+					iocPage.setEnableCommandLineHistory(true);
+				}
+			}
+		}
+	}
+
+	@Override
+	public void dispose() {
+	}
+
+	@Override
+	public void activated() {
+	}
+
+	@Override
+	public void deactivated() {
+	}
+}

--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleFixedWidthTests.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleFixedWidthTests.java
@@ -21,8 +21,8 @@ import org.eclipse.debug.tests.TestUtil;
 public class IOConsoleFixedWidthTests extends IOConsoleTests {
 
 	@Override
-	protected IOConsoleTestUtil getTestUtil(String title) {
-		final IOConsoleTestUtil c = super.getTestUtil(title);
+	protected IOConsoleTestUtil getTestUtil(String title, String... attrValues) {
+		final IOConsoleTestUtil c = super.getTestUtil(title, attrValues);
 		// Varying the width may reveal new bugs. There is no width value
 		// which is invalid. (but remember most test output is quite short)
 		// And try the most beautiful width of 1 aka the vertical console.

--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/console/IOConsoleTestUtil.java
@@ -401,6 +401,10 @@ public final class IOConsoleTestUtil {
 		return this;
 	}
 
+	public int getTextPanelCharCount() {
+		return textPanel.getCharCount();
+	}
+
 	/**
 	 * Set caret to offset relative to start of current line.
 	 *

--- a/org.eclipse.ui.console/plugin.properties
+++ b/org.eclipse.ui.console/plugin.properties
@@ -22,7 +22,12 @@ ConsolePageParticipantName= Console Page Participants
 ConsoleFactoryName= Console Factories
 
 consoleViewConsoleFactory.name=New Console View
-
+consoleViewCategory=active within a process console
+consoleViewCategoryName=Console
+consoleViewPrevCommandDescription=Retrieve a previously-executed command
+consoleViewPrevCommandName=Show Previous Command In History
+consoleViewNextCommandDescription=Retrieve a later-executed command
+consoleViewNextCommandName=Show Next Command In History
 context.consoleview.name=In Console View
 context.consoleview.description=In Console View
 

--- a/org.eclipse.ui.console/plugin.xml
+++ b/org.eclipse.ui.console/plugin.xml
@@ -176,4 +176,58 @@ M4 = Platform-specific fourth key
       </consolePageParticipant>
     </extension>
 
+    <extension point="org.eclipse.ui.commands">
+      <category
+            description="%consoleViewCategory"
+            id="org.eclipse.ui.console.history_commands.category"
+            name="%consoleViewCategoryName">
+      </category>
+      <command
+            categoryId="org.eclipse.ui.console.history_commands.category"
+            description="%consoleViewPrevCommandDescription"
+            id="org.eclipse.ui.console.showPreviousCommand"
+            name="%consoleViewPrevCommandName">
+      </command>
+      <command
+            categoryId="org.eclipse.ui.console.history_commands.category"
+            description="%consoleViewNextCommandDescription"
+            id="org.eclipse.ui.console.showNextCommand"
+            name="%consoleViewNextCommandName">
+      </command>
+    </extension>
+    <extension
+          point="org.eclipse.ui.handlers">
+       <handler
+             class="org.eclipse.ui.console.actions.ShowPreviousCommandHandler"
+             commandId="org.eclipse.ui.console.showPreviousCommand">
+          <activeWhen>
+          	<with variable="activePartId">
+        		<equals value="org.eclipse.ui.console.ConsoleView"/>
+    		</with>
+          </activeWhen>
+       </handler>
+       <handler
+             class="org.eclipse.ui.console.actions.ShowNextCommandHandler"
+             commandId="org.eclipse.ui.console.showNextCommand">
+          <activeWhen>
+          	<with variable="activePartId">
+        		<equals value="org.eclipse.ui.console.ConsoleView"/>
+    		</with>
+          </activeWhen>
+       </handler>
+    </extension>
+    <extension point="org.eclipse.ui.bindings">
+      <key
+            commandId="org.eclipse.ui.console.showPreviousCommand"
+            contextId="org.eclipse.debug.ui.console"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+ARROW_UP">
+      </key>
+      <key
+            commandId="org.eclipse.ui.console.showNextCommand"
+            contextId="org.eclipse.debug.ui.console"
+            schemeId="org.eclipse.ui.defaultAcceleratorConfiguration"
+            sequence="M1+ARROW_DOWN">
+      </key>
+    </extension>
 </plugin>

--- a/org.eclipse.ui.console/src/org/eclipse/ui/console/IIOConsolePage.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/console/IIOConsolePage.java
@@ -1,0 +1,23 @@
+package org.eclipse.ui.console;
+
+import org.eclipse.ui.part.IPageBookViewPage;
+
+/**
+ * An IO console page appears in a page book and can be used to enable command
+ * line history for the console.
+ *
+ * @since 3.12
+ */
+public interface IIOConsolePage extends IPageBookViewPage {
+	/**
+	 * Enable command line history. Command lines (lines entered by the user) will
+	 * be collected and maintained in a history. Ctrl-up arrow and ctrl-down arrow
+	 * can be used to move through the history. The history line will be shown as
+	 * user input.
+	 * <p>
+	 * Generally called from an {@link IConsolePageParticipant}
+	 *
+	 * @param enable enable command line history.
+	 */
+	void setEnableCommandLineHistory(boolean enable);
+}

--- a/org.eclipse.ui.console/src/org/eclipse/ui/console/IOConsole.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/console/IOConsole.java
@@ -23,9 +23,12 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.eclipse.core.commands.ExecutionException;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IDocumentPartitioner;
 import org.eclipse.ui.WorkbenchEncoding;
+import org.eclipse.ui.internal.console.ConsoleDocument;
 import org.eclipse.ui.internal.console.IOConsolePage;
 import org.eclipse.ui.internal.console.IOConsolePartitioner;
 import org.eclipse.ui.part.IPageBookViewPage;
@@ -122,6 +125,19 @@ public class IOConsole extends TextConsole {
 			partitioner.connect(document);
 			document.setDocumentPartitioner(partitioner);
 		}
+	}
+
+	/**
+	 * Enable command line history.
+	 * <p>
+	 * Not usually called directly. Instead call via {@link IConsolePageParticipant}
+	 * to ensure proper management of the cursor.
+	 *
+	 * @param enable Enable it.
+	 * @since 3.12
+	 */
+	public void setEnableCommandLineHistory(boolean enable) {
+		partitioner.setEnableCommandLineHistory(enable);
 	}
 
 	/**
@@ -410,5 +426,46 @@ public class IOConsole extends TextConsole {
 		synchronized (openStreams) {
 			openStreams.add(stream);
 		}
+	}
+
+	/**
+	 * Show the previous command line history entry.
+	 *
+	 * @throws ExecutionException Previous command line entry in history exists, but
+	 *                            was unable insert it.
+	 * @since 3.12
+	 */
+	public void showPreviousCommand() throws ExecutionException {
+		IOConsolePartitioner ioConsolePartitioner = findIOConsoleParitioner();
+		if (ioConsolePartitioner != null) {
+			ioConsolePartitioner.showPreviousCommand();
+		}
+	}
+
+	/**
+	 * Show the next command line history entry.
+	 *
+	 * @throws ExecutionException Next command line entry in history exists, but was
+	 *                            unable insert it.
+	 * @since 3.12
+	 */
+	public void showNextCommand() throws ExecutionException {
+		IOConsolePartitioner ioConsolePartitioner = findIOConsoleParitioner();
+		if (ioConsolePartitioner != null) {
+			ioConsolePartitioner.showNextCommand();
+		}
+	}
+
+	private IOConsolePartitioner findIOConsoleParitioner() {
+		final IDocument document = getDocument();
+		if (document instanceof ConsoleDocument) {
+			final ConsoleDocument consoleDocument = (ConsoleDocument) document;
+			// Find the document partitioner for the text document.
+			final IDocumentPartitioner documentPartitioner = consoleDocument.getDocumentPartitioner();
+			if (documentPartitioner instanceof IOConsolePartitioner) {
+				return (IOConsolePartitioner) documentPartitioner;
+			}
+		}
+		return null;
 	}
 }

--- a/org.eclipse.ui.console/src/org/eclipse/ui/console/IOConsoleInputStream.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/console/IOConsoleInputStream.java
@@ -77,9 +77,15 @@ public class IOConsoleInputStream extends InputStream {
 	/**
 	 * Constructs a new input stream on the given console.
 	 *
+	 * This constructor is public so clients can use it to intercept keyboard output
+	 * from an IOConsole by using
+	 * <code>IOConsole.setInputStream(InputStream inputStream)</code>. This can be
+	 * used to log, filter, transform user input.
+	 *
 	 * @param console I/O console
+	 * @since 3.12
 	 */
-	IOConsoleInputStream(IOConsole console) {
+	public IOConsoleInputStream(IOConsole console) {
 		this.console = console;
 	}
 

--- a/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsoleViewer.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsoleViewer.java
@@ -93,7 +93,6 @@ public class TextConsoleViewer extends SourceViewer implements LineStyleListener
 
 	private boolean consoleAutoScrollLock = true;
 
-
 	private IPropertyChangeListener propertyChangeListener;
 
 	private IScrollLockStateProvider scrollLockStateProvider;
@@ -224,8 +223,6 @@ public class TextConsoleViewer extends SourceViewer implements LineStyleListener
 	public TextConsoleViewer(Composite parent, TextConsole console, IScrollLockStateProvider scrollLockStateProvider) {
 		this(parent, console);
 		this.scrollLockStateProvider = scrollLockStateProvider;
-
-
 	}
 
 	/**
@@ -853,5 +850,11 @@ public class TextConsoleViewer extends SourceViewer implements LineStyleListener
 		}
 	}
 
-
+	/**
+	 * @return The console this viewer shows.
+	 * @since 3.12
+	 */
+	public TextConsole getConsole() {
+		return console;
+	}
 }

--- a/org.eclipse.ui.console/src/org/eclipse/ui/console/actions/ShowNextCommandHandler.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/console/actions/ShowNextCommandHandler.java
@@ -1,0 +1,29 @@
+package org.eclipse.ui.console.actions;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IOConsole;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.ui.internal.console.ConsoleView;
+
+/**
+ * @since 3.12
+ */
+public class ShowNextCommandHandler extends AbstractHandler {
+	@Override
+	public final Object execute(ExecutionEvent event) throws ExecutionException {
+		// First find the console window.
+		final IWorkbenchPart part = HandlerUtil.getActivePart(event);
+		if (part instanceof ConsoleView) {
+			final IConsole console = ((ConsoleView) part).getConsole();
+			if (console instanceof IOConsole) {
+				IOConsole ioConsole = (IOConsole) console;
+				ioConsole.showNextCommand();
+			}
+		}
+		return null;
+	}
+}

--- a/org.eclipse.ui.console/src/org/eclipse/ui/console/actions/ShowPreviousCommandHandler.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/console/actions/ShowPreviousCommandHandler.java
@@ -1,0 +1,29 @@
+package org.eclipse.ui.console.actions;
+
+import org.eclipse.core.commands.AbstractHandler;
+import org.eclipse.core.commands.ExecutionEvent;
+import org.eclipse.core.commands.ExecutionException;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.console.IConsole;
+import org.eclipse.ui.console.IOConsole;
+import org.eclipse.ui.handlers.HandlerUtil;
+import org.eclipse.ui.internal.console.ConsoleView;
+
+/**
+ * @since 3.12
+ */
+public class ShowPreviousCommandHandler extends AbstractHandler {
+	@Override
+	public final Object execute(ExecutionEvent event) throws ExecutionException {
+		// First find the console window.
+		final IWorkbenchPart part = HandlerUtil.getActivePart(event);
+		if (part instanceof ConsoleView) {
+			final IConsole console = ((ConsoleView) part).getConsole();
+			if (console instanceof IOConsole) {
+				IOConsole ioConsole = (IOConsole) console;
+				ioConsole.showPreviousCommand();
+			}
+		}
+		return null;
+	}
+}

--- a/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/CommandLineHistory.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/CommandLineHistory.java
@@ -1,0 +1,67 @@
+package org.eclipse.ui.internal.console;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Maintains a history of ProcessConsole commands entered by the user.
+ */
+public class CommandLineHistory {
+	/** The list of commands that have been executed. (no nulls) */
+	private List<String> _history = new ArrayList<>();
+
+	/**
+	 * The currently selected command in the list. Always >= 0 and <=
+	 * _commandHistory.size().
+	 */
+	private int _currentIndex = 0;
+
+	public void addCommand(String command) {
+		assert command != null;
+		synchronized (this) {
+			_history.add(command.replaceFirst("^(.*)(\r|\n|\r\n)$", "$1")); //$NON-NLS-1$ //$NON-NLS-2$
+			_currentIndex = _history.size();
+		}
+	}
+
+	/**
+	 * Retreat to the previous command in the given document's command history and
+	 * return it. Returns an empty string if the history is empty. Does not retreat
+	 * if the current command is the first in the history.
+	 *
+	 * @return The previous command in the history.
+	 */
+	public String prevCommand() {
+		synchronized (this) {
+			if (_currentIndex > 0) {
+				--_currentIndex;
+			}
+			return currentCommand();
+		}
+	}
+
+	/**
+	 * Advance (if possible) to the next command in the given document's command
+	 * history and return it. Returns an empty string if the history is empty. Can
+	 * advance to at most one position past the last command in the history (which
+	 * will result in an empty string).
+	 *
+	 * @return The next command in the history.
+	 */
+	public String nextCommand() {
+		synchronized (this) {
+			if (_currentIndex < _history.size()) {
+				++_currentIndex;
+			}
+			return currentCommand();
+		}
+	}
+
+	/**
+	 * @return Return the current command if it's within the history, or an empty
+	 *         string otherwise.
+	 */
+	private String currentCommand() {
+		return (_currentIndex < _history.size()) ? _history.get(_currentIndex) : ""; //$NON-NLS-1$
+	}
+}

--- a/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/IOConsolePage.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/internal/console/IOConsolePage.java
@@ -21,6 +21,7 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.ui.actions.ActionFactory;
 import org.eclipse.ui.console.IConsoleConstants;
 import org.eclipse.ui.console.IConsoleView;
+import org.eclipse.ui.console.IIOConsolePage;
 import org.eclipse.ui.console.TextConsole;
 import org.eclipse.ui.console.TextConsolePage;
 import org.eclipse.ui.console.TextConsoleViewer;
@@ -31,7 +32,7 @@ import org.eclipse.ui.console.TextConsoleViewer;
  * @since 3.1
  *
  */
-public class IOConsolePage extends TextConsolePage {
+public class IOConsolePage extends TextConsolePage implements IIOConsolePage {
 
 	private ScrollLockAction fScrollLockAction;
 	private WordWrapAction fWordWrapAction;
@@ -74,6 +75,14 @@ public class IOConsolePage extends TextConsolePage {
 		if (viewer != null) {
 			viewer.setAutoScroll(scroll);
 			fScrollLockAction.setChecked(!scroll);
+		}
+	}
+
+	@Override
+	public void setEnableCommandLineHistory(boolean enable) {
+		IOConsoleViewer viewer = (IOConsoleViewer) getViewer();
+		if (viewer != null) {
+			viewer.setEnableCommandLineHistory(enable);
 		}
 	}
 


### PR DESCRIPTION
This adds history to the ProcessConsole.  Use ctrl-up and ctrl-down to move through the history.

The code for the history has actually been added to the package for IOConsole.  However, I didn't want to change the behavior of IOConsole. The ProcessConsole constructor simply passes a flag to IOConsole to enable the history.  The existing constructor for IOConsole passes a false to a new version of the IOConsole constructor to disable history. Thus existing code using the existing constructor will still work as before.

The actual work for collecting history is in IOConsolePartitioner.

I fixed a bug in IOConsolePartitioner.computePartitioning.  There was a simple off by one type of error while looping through partitions to see which ones spanned the input region.  The loop was exited too early.  This fix is necessary for the history to work.

I fixed a bug in IOConsoleViewer.  When a user types input and the cursor is in a non-writable partition, there was code to insert the text into the beginning of the writable partition.  However it's more natural to add it to the end of that partition.  Consider the situation where the user has typed some input, perhaps "show info ". Then goes to a location earlier in the console to select a variable name and copy and paste it.  The user expects the pasted text to go after the text already typed.  That is they expect "show info var", not "varshow info ".  This fix is necessary for history.

In TextConsoleViewer, I changed the reveal job to optionally move the cursor to the end of the text widget.  This job is invoked if auto scroll is on.  When a document modification occurs at the end of the document, the cursor is also moved to the end of the document.  This is necessary for when a history line is placed in the document using ctrl-up or ctrl-down.

--
Capturing Keyboard Input from IOConsole

[Here is a very small change which could be separated into another branch.  I'm hoping this will be accepted in the same change as the history.

Perhaps someone knows of a better way to do this.
]

The constructor for IOConsoleInputStream has been made public.  This is the stream which receives keyboard input from a console once enter is pressed.  By making it public, a developer can set their own input stream.  This allows for logging, transforming and filtering user input before it is sent to the process. The only way IOConsoleParition will pass the text typed by the user to the stream is if it is an IOConsoleInputStream.

As background, IOConsole has a method to set the input stream, and
another to get the input stream.   getInputStream() returns
IOConsoleInputStream.  However, setInputStream() accepts the more basic
InputStream.  I'm not sure why the asymmetry.