### PR TITLE
Expand launches provided by ILaunchShortcut2

### DIFF
--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/LaunchShortcutAction.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/actions/LaunchShortcutAction.java
@@ -48,6 +48,7 @@ public class LaunchShortcutAction extends Action {
 
 	private String fMode;
 	private LaunchShortcutExtension fShortcut;
+	private ILaunchConfiguration configuration;
 
 
 	/**
@@ -63,6 +64,14 @@ public class LaunchShortcutAction extends Action {
 		updateEnablement();
 	}
 
+	public LaunchShortcutAction(String mode, LaunchShortcutExtension shortcut, ILaunchConfiguration configuration) {
+		super(configuration.getName(), shortcut.getImageDescriptor());
+		fShortcut = shortcut;
+		fMode = mode;
+		this.configuration = configuration;
+		updateEnablement();
+	}
+
 	/**
 	 * Runs with either the active editor or workbench selection.
 	 *
@@ -74,6 +83,10 @@ public class LaunchShortcutAction extends Action {
 	}
 
 	private void runInternal(boolean isShift) {
+		if (configuration != null) {
+			DebugUITools.launch(configuration, fMode);
+			return;
+		}
 		IStructuredSelection ss = SelectedResourceManager.getDefault().getCurrentSelection();
 		Object o = ss.getFirstElement();
 		// store if Shift was pressed to toggle terminate before launch


### PR DESCRIPTION
Currently ILaunchShortcut2 is only queried for the launch button but not when one uses the context menu, this adds expanding the items from a ILaunchShortcut2 to be added to the Run As / Debug As / ... menus.

FYI @mickaelistria 
This is related to
- https://github.com/eclipse-m2e/m2e-core/pull/1309