### PR TITLE
Run context menu missing some entries

### DIFF
--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/ContextualLaunchAction.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/ContextualLaunchAction.java
@@ -236,7 +236,7 @@ public abstract class ContextualLaunchAction implements IObjectActionDelegate, I
 						categories.add(category);
 					}
 					ILaunchConfiguration[] configurations = ext.getLaunchConfigurations(ss);
-					if (configurations == null) {
+					if (configurations == null || configurations.length == 0) {
 						populateMenuItem(mode, ext, menu, null, accelerator++);
 					} else if (configurations.length > 0) {
 						for (ILaunchConfiguration configuration : configurations) {


### PR DESCRIPTION
When the shortcut refers to no specific launch configuration and returns an empty array, show the shortcut as usual.