### PR TITLE
Properly resize Launch configuration controls

### DIFF
--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/SWTFactory.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/SWTFactory.java
@@ -252,20 +252,21 @@ public class SWTFactory {
 	/**
 	 * Creates a new label widget
 	 *
-	 * @param parent  the parent composite to add this label widget to
-	 * @param text    the text for the label
-	 * @param hspan   the horizontal span to take up in the parent composite
-	 * @param gdSpace to grab the excess horizontal space of the Label
+	 * @param parent     the parent composite to add this label widget to
+	 * @param text       the text for the label
+	 * @param hspan      the horizontal span to take up in the parent composite
+	 * @param grabHSpace specifies whether the width of the label changes depending
+	 *                   on the size of the parent Composite
 	 * @return the new label
 	 * @since 3.18
 	 */
-	public static Label createLabel(Composite parent, String text, int hspan, boolean gdSpace) {
+	public static Label createLabel(Composite parent, String text, int hspan, boolean grabHSpace) {
 		Label l = new Label(parent, SWT.NONE);
 		l.setFont(parent.getFont());
 		l.setText(text);
 		GridData gd = new GridData(GridData.FILL_HORIZONTAL);
 		gd.horizontalSpan = hspan;
-		gd.grabExcessHorizontalSpace = gdSpace;
+		gd.grabExcessHorizontalSpace = grabHSpace;
 		l.setLayoutData(gd);
 		return l;
 	}

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/SWTFactory.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/SWTFactory.java
@@ -250,6 +250,27 @@ public class SWTFactory {
 	}
 
 	/**
+	 * Creates a new label widget
+	 *
+	 * @param parent  the parent composite to add this label widget to
+	 * @param text    the text for the label
+	 * @param hspan   the horizontal span to take up in the parent composite
+	 * @param gdSpace to grab the excess horizontal space of the Label
+	 * @return the new label
+	 * @since 3.18
+	 */
+	public static Label createLabel(Composite parent, String text, int hspan, boolean gdSpace) {
+		Label l = new Label(parent, SWT.NONE);
+		l.setFont(parent.getFont());
+		l.setText(text);
+		GridData gd = new GridData(GridData.FILL_HORIZONTAL);
+		gd.horizontalSpan = hspan;
+		gd.grabExcessHorizontalSpace = gdSpace;
+		l.setLayoutData(gd);
+		return l;
+	}
+
+	/**
 	 * Creates a wrapping label
 	 * @param parent the parent composite to add this label to
 	 * @param text the text to be displayed in the label

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationView.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationView.java
@@ -45,7 +45,6 @@ import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
-import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
@@ -441,9 +440,8 @@ public class LaunchConfigurationView extends AbstractDebugView implements ILaunc
 		if (getViewer() instanceof StructuredViewer) {
 			((StructuredViewer)getViewer()).addDoubleClickListener(this);
 		}
-		fFilteredNotice = SWTFactory.createLabel(parent, IInternalDebugCoreConstants.EMPTY_STRING, 1);
+		fFilteredNotice = SWTFactory.createLabel(parent, IInternalDebugCoreConstants.EMPTY_STRING, 1, true);
 		fFilteredNotice.setBackground(parent.getBackground());
-		((GridData) fFilteredNotice.getLayoutData()).grabExcessHorizontalSpace = true;
 	}
 
 	/**

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationView.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/launchConfigurations/LaunchConfigurationView.java
@@ -45,6 +45,7 @@ import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
+import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.Label;
@@ -442,6 +443,7 @@ public class LaunchConfigurationView extends AbstractDebugView implements ILaunc
 		}
 		fFilteredNotice = SWTFactory.createLabel(parent, IInternalDebugCoreConstants.EMPTY_STRING, 1);
 		fFilteredNotice.setBackground(parent.getBackground());
+		((GridData) fFilteredNotice.getLayoutData()).grabExcessHorizontalSpace = true;
 	}
 
 	/**


### PR DESCRIPTION
The text widget in both run and debug configurations follow the sashing only partially - at some point, the filter text overlays into the neighboring areas. this is because of the conflicting layoutdata property defined for the text and the label controls in the parent composite. if grabExcessHorizontalSpace property is set to true for one and false for another child controls, the layout gets convoluted, or follow only one of the request.

The issue is there in Windows as well but not visible due to the absence of focus ring. The issue was due to not grabbing the horizontal space for the Label attached to the bottom of the composite area. Making the grabExcessHorizontalSpace variable of GridData to true resolves the issue.

Fix is to force the same flag in both the cases leading to properly laying out the children widgets in the composite.

Fixes: https://github.com/eclipse-platform/eclipse.platform.debug/issues/130