### PR TITLE
Improve OSGi metadata about dependency to javax.inject/annotations

### DIFF
--- a/org.eclipse.debug.ui.launchview/META-INF/MANIFEST.MF
+++ b/org.eclipse.debug.ui.launchview/META-INF/MANIFEST.MF
@@ -13,8 +13,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.e4.ui.di,
  org.eclipse.e4.ui.services
 Bundle-RequiredExecutionEnvironment: JavaSE-17
-Import-Package: javax.annotation;version="1.0.0";resolution:=optional,
- javax.inject;version="1.0.0"
+Import-Package: javax.annotation;version="[1.0.0,2.0.0)",
+ javax.inject;version="[1.0.0,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Service-Component: OSGI-INF/org.eclipse.debug.ui.launchview.internal.model.LaunchViewModel.xml,
  OSGI-INF/org.eclipse.debug.ui.launchview.internal.impl.DebugCoreProvider.xml


### PR DESCRIPTION
- Always use closed version ranges [1.X,2) with a minor lower bound
- Mark package-import that is not optional as such

Part of https://github.com/eclipse-platform/eclipse.platform.releng.aggregator/issues/1056