### PR TITLE
Make memory view cell editor visible on Linux GTK3 #132

### DIFF
--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/memory/renderings/AsyncTableRenderingViewer.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/memory/renderings/AsyncTableRenderingViewer.java
@@ -730,8 +730,8 @@ public class AsyncTableRenderingViewer extends AsyncVirtualContentTableViewer {
 				fCellEditorListener = new CellEditorListener(row, col, editor);
 				editor.addListener(fCellEditorListener);
 
-				// move cursor below editor control
-				fTableCursor.moveBelow(control);
+				// Set cursor visibility to false
+				fTableCursor.setVisible(false);
 			}
 		}
 	}
@@ -739,7 +739,7 @@ public class AsyncTableRenderingViewer extends AsyncVirtualContentTableViewer {
 	private void deactivateEditor(CellEditor editor)
 	{
 		removeListeners(editor.getControl());
-		fTableCursor.moveAbove(editor.getControl());
+		fTableCursor.setVisible(true);
 		fTableCursor.setFocus();
 	}
 


### PR DESCRIPTION
Make memory view cell editor visible on Linux GTK3 #132

Since SWT change from GTK2 to GTK3 as its backend the cell
editing in the memory view has not worked properly
with the cell editor not visible. This change uses explicit
setVisible rather than adjusting Z-order of the controls.

Fixes https://github.com/eclipse-platform/eclipse.platform.debug/issues/132