### PR TITLE
Console hyperlinks not accessible while process still running

### DIFF
--- a/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsoleViewer.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsoleViewer.java
@@ -105,7 +105,7 @@ public class TextConsoleViewer extends SourceViewer implements LineStyleListener
 
 		@Override
 		public void documentChanged(DocumentEvent event) {
-			updateLinks(event.fOffset);
+			updateLinks(getTextWidget().getCaretOffset());
 		}
 	};
 	// event listener used to send event to hyperlink for IHyperlink2
@@ -569,6 +569,7 @@ public class TextConsoleViewer extends SourceViewer implements LineStyleListener
 		if (handCursor == null) {
 			handCursor = ConsolePlugin.getStandardDisplay().getSystemCursor(SWT.CURSOR_HAND);
 		}
+
 		return handCursor;
 	}
 

--- a/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsoleViewer.java
+++ b/org.eclipse.ui.console/src/org/eclipse/ui/console/TextConsoleViewer.java
@@ -569,7 +569,6 @@ public class TextConsoleViewer extends SourceViewer implements LineStyleListener
 		if (handCursor == null) {
 			handCursor = ConsolePlugin.getStandardDisplay().getSystemCursor(SWT.CURSOR_HAND);
 		}
-
 		return handCursor;
 	}
 


### PR DESCRIPTION
Hyperlinks are not accessible while the process is still logging eclipse-platform/eclipse.platform#529

On document change, the links should be updated at the current offset, not at the offset of the event.

Fixes https://github.com/eclipse-platform/eclipse.platform/issues/529