### PR TITLE
Marker id ... not found when launching debuggee Eclipse

### DIFF
--- a/org.eclipse.debug.core/core/org/eclipse/debug/core/model/LaunchConfigurationDelegate.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/core/model/LaunchConfigurationDelegate.java
@@ -385,7 +385,7 @@ public abstract class LaunchConfigurationDelegate implements ILaunchConfiguratio
 			if (severity != null) {
 				return severity.intValue() >= IMarker.SEVERITY_ERROR;
 			}
-		} catch (IllegalStateException e) {
+		} catch (CoreException e) {
 			// Ignore if the marker no longer exists, see:
 			// https://github.com/eclipse-platform/eclipse.platform.debug/issues/136
 			if (problemMarker.exists()) {


### PR DESCRIPTION
Adjusted the exception type caught in
`LaunchConfigurationDelegate.isLaunchProblem(IMarker)`, to match the thrown `ResourceException`.

Fixes: #136