### PR TITLE
Use new static IPath factories and constants

### DIFF
--- a/org.eclipse.core.externaltools/META-INF/MANIFEST.MF
+++ b/org.eclipse.core.externaltools/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.core.externaltools;singleton:=true
-Bundle-Version: 1.3.0.qualifier
+Bundle-Version: 1.3.100.qualifier
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.debug.core;bundle-version="[3.9.0,4.0.0)",
  org.eclipse.core.variables;bundle-version="[3.2.800,4.0.0)"

--- a/org.eclipse.core.externaltools/META-INF/MANIFEST.MF
+++ b/org.eclipse.core.externaltools/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %pluginName
 Bundle-Localization: plugin
 Bundle-SymbolicName: org.eclipse.core.externaltools;singleton:=true
 Bundle-Version: 1.3.100.qualifier
-Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.5.0,4.0.0)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.debug.core;bundle-version="[3.9.0,4.0.0)",
  org.eclipse.core.variables;bundle-version="[3.2.800,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.core.externaltools/src/org/eclipse/core/externaltools/internal/launchConfigurations/ExternalToolsCoreUtil.java
+++ b/org.eclipse.core.externaltools/src/org/eclipse/core/externaltools/internal/launchConfigurations/ExternalToolsCoreUtil.java
@@ -26,7 +26,6 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.variables.IStringVariableManager;
@@ -80,7 +79,7 @@ public class ExternalToolsCoreUtil {
 			} else {
 				File file = new File(expandedLocation);
 				if (file.isFile()) {
-					return new Path(expandedLocation);
+					return IPath.fromOSString(expandedLocation);
 				}
 
 				String msg = NLS.bind(ExternalToolsProgramMessages.ExternalToolsUtil_invalidLocation__0_, new Object[] { configuration.getName()});
@@ -125,7 +124,7 @@ public class ExternalToolsCoreUtil {
 			if (expandedLocation.length() > 0) {
 				File path = new File(expandedLocation);
 				if (path.isDirectory()) {
-					return new Path(expandedLocation);
+					return IPath.fromOSString(expandedLocation);
 				}
 				String msg = NLS.bind(ExternalToolsProgramMessages.ExternalToolsUtil_invalidDirectory__0_, new Object[] { expandedLocation, configuration.getName()});
 				abort(msg, null, 0);
@@ -240,7 +239,7 @@ public class ExternalToolsCoreUtil {
 			IStringVariableManager manager = VariablesPlugin.getDefault().getStringVariableManager();
 			try {
 				String pathString = manager.performStringSubstitution("${selected_resource_path}"); //$NON-NLS-1$
-				IResource res = ResourcesPlugin.getWorkspace().getRoot().findMember(new Path(pathString));
+				IResource res = ResourcesPlugin.getWorkspace().getRoot().findMember(IPath.fromOSString(pathString));
 				if (res != null && res.getProject() != null) {
 					return new IProject[]{res.getProject()};
 				}

--- a/org.eclipse.core.externaltools/src/org/eclipse/core/externaltools/internal/model/BuilderCoreUtils.java
+++ b/org.eclipse.core.externaltools/src/org/eclipse/core/externaltools/internal/model/BuilderCoreUtils.java
@@ -27,7 +27,6 @@ import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
@@ -89,7 +88,7 @@ public class BuilderCoreUtils {
 		ILaunchConfiguration configuration = null;
 		if (configHandle.startsWith(PROJECT_TAG)) {
 			version[0] = VERSION_3_0_final;
-			IPath path = new Path(configHandle);
+			IPath path = IPath.fromOSString(configHandle);
 			IFile file = project.getFile(path.removeFirstSegments(1));
 			if (file.exists()) {
 				configuration = manager.getLaunchConfiguration(file);
@@ -97,7 +96,7 @@ public class BuilderCoreUtils {
 		} else {
 			// Try treating the handle as a file name.
 			// This is the format used in 3.0 RC1.
-			IPath path = new Path(BUILDER_FOLDER_NAME).append(configHandle);
+			IPath path = IPath.fromOSString(BUILDER_FOLDER_NAME).append(configHandle);
 			IFile file = project.getFile(path);
 			if (file.exists()) {
 				version[0] = VERSION_3_0_interim;

--- a/org.eclipse.core.variables/META-INF/MANIFEST.MF
+++ b/org.eclipse.core.variables/META-INF/MANIFEST.MF
@@ -8,7 +8,7 @@ Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Export-Package: org.eclipse.core.internal.variables;x-internal:=true,
  org.eclipse.core.variables
-Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.3.0,4.0.0)"
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17
 Automatic-Module-Name: org.eclipse.core.variables

--- a/org.eclipse.core.variables/META-INF/MANIFEST.MF
+++ b/org.eclipse.core.variables/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.core.variables; singleton:=true
-Bundle-Version: 3.6.0.qualifier
+Bundle-Version: 3.6.100.qualifier
 Bundle-Activator: org.eclipse.core.variables.VariablesPlugin
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin

--- a/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/EclipseHomeVariableResolver.java
+++ b/org.eclipse.core.variables/src/org/eclipse/core/internal/variables/EclipseHomeVariableResolver.java
@@ -18,7 +18,6 @@ import java.net.URL;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.variables.IDynamicVariable;
 import org.eclipse.core.variables.IDynamicVariableResolver;
@@ -42,7 +41,7 @@ public class EclipseHomeVariableResolver implements IDynamicVariableResolver {
 				// how other variables, like ${workspace_loc} resolve. See
 				// ResourceResolver.translateToValue(). [bugzilla 263535]
 				String file = url.getFile();
-				IPath path = Path.fromOSString(file);
+				IPath path = IPath.fromOSString(file);
 				String osstr = path.toOSString();
 				if (osstr.length() != 0) {
 					return osstr;

--- a/org.eclipse.debug.core/META-INF/MANIFEST.MF
+++ b/org.eclipse.debug.core/META-INF/MANIFEST.MF
@@ -21,7 +21,7 @@ Export-Package: org.eclipse.debug.core,
  org.eclipse.debug.internal.core.variables;x-friends:="org.eclipse.debug.ui,org.eclipse.jdt.debug.ui"
 Require-Bundle: org.eclipse.core.resources;bundle-version="[3.18.0,4.0.0)";visibility:=reexport,
  org.eclipse.core.variables;bundle-version="[3.2.800,4.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.26.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.core.expressions;bundle-version="[3.4.0,4.0.0)"
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.debug.core/core/org/eclipse/debug/core/RefreshUtil.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/core/RefreshUtil.java
@@ -24,10 +24,10 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IAdaptable;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
 import org.eclipse.core.variables.IStringVariableManager;
@@ -159,7 +159,7 @@ public class RefreshUtil {
 		if (memento.startsWith("${resource:")) { //$NON-NLS-1$
 			// This is an old format that is replaced with 'working_set'
 			String pathString = memento.substring(11, memento.length() - 1);
-			Path path = new Path(pathString);
+			IPath path = IPath.fromOSString(pathString);
 			IResource resource = ResourcesPlugin.getWorkspace().getRoot().findMember(path);
 			if (resource == null) {
 				throw new CoreException(new Status(IStatus.ERROR, DebugPlugin.getUniqueIdentifier(), IStatus.ERROR, MessageFormat.format(DebugCoreMessages.RefreshUtil_1, pathString), null));
@@ -176,7 +176,7 @@ public class RefreshUtil {
 			IResource resource = null;
 			try {
 				String pathString = manager.performStringSubstitution("${selected_resource_path}"); //$NON-NLS-1$
-				resource = ResourcesPlugin.getWorkspace().getRoot().findMember(new Path(pathString));
+				resource = ResourcesPlugin.getWorkspace().getRoot().findMember(IPath.fromOSString(pathString));
 			} catch (CoreException e) {
 				// unable to resolve a resource
 			}

--- a/org.eclipse.debug.core/core/org/eclipse/debug/core/sourcelookup/containers/ContainerSourceContainer.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/core/sourcelookup/containers/ContainerSourceContainer.java
@@ -29,7 +29,6 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.sourcelookup.ISourceContainer;
 
 /**
@@ -94,7 +93,7 @@ public abstract class ContainerSourceContainer extends CompositeSourceContainer 
 		// To prevent the interruption of the search procedure we check
 		// if the path is valid before passing it to "getFile".
 		if ( validateFile(name) ) {
-			IFile file = fContainer.getFile(new Path(name));
+			IFile file = fContainer.getFile(IPath.fromOSString(name));
 			if (file.exists()) {
 				sources.add(file);
 			} else {
@@ -105,7 +104,7 @@ public abstract class ContainerSourceContainer extends CompositeSourceContainer 
 				// bug 295828 root file may be null for an invalid linked resource
 				if (fRootFile != null) {
 					// See bug 98090 - we need to handle relative path names
-					IFileStore target = fRootFile.getFileStore(new Path(name));
+					IFileStore target = fRootFile.getFileStore(IPath.fromOSString(name));
 					if (target.fetchInfo().exists()) {
 						// We no longer have to account for bug 95832, and URIs take care
 						// of canonical paths (fix to bug 95679 was removed).

--- a/org.eclipse.debug.core/core/org/eclipse/debug/core/sourcelookup/containers/LocalFileStorage.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/core/sourcelookup/containers/LocalFileStorage.java
@@ -22,7 +22,6 @@ import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugPlugin;
@@ -66,7 +65,7 @@ public class LocalFileStorage extends PlatformObject implements IStorage {
 	@Override
 	public IPath getFullPath() {
 		try {
-			return new Path(getFile().getCanonicalPath());
+			return IPath.fromOSString(getFile().getCanonicalPath());
 		} catch (IOException e) {
 			DebugPlugin.log(e);
 			return null;

--- a/org.eclipse.debug.core/core/org/eclipse/debug/core/sourcelookup/containers/ZipEntryStorage.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/core/sourcelookup/containers/ZipEntryStorage.java
@@ -23,7 +23,6 @@ import org.eclipse.core.resources.IStorage;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugPlugin;
@@ -74,7 +73,7 @@ public class ZipEntryStorage extends PlatformObject implements IStorage {
 
 	@Override
 	public IPath getFullPath() {
-		return new Path(getArchive().getName()).append(getZipEntry().getName());
+		return IPath.fromOSString(getArchive().getName()).append(getZipEntry().getName());
 	}
 
 	@Override

--- a/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchConfiguration.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchConfiguration.java
@@ -45,7 +45,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
@@ -221,7 +220,7 @@ public class LaunchConfiguration extends PlatformObject implements ILaunchConfig
 	 * @since 3.5
 	 */
 	protected static String getSimpleName(String fileName) {
-		IPath path = new Path(fileName);
+		IPath path = IPath.fromOSString(fileName);
 		if(ILaunchConfiguration.LAUNCH_CONFIGURATION_FILE_EXTENSION.equals(path.getFileExtension())) {
 			return path.removeFileExtension().toString();
 		} else if (ILaunchConfiguration.LAUNCH_CONFIGURATION_PROTOTYPE_FILE_EXTENSION.equals(path.getFileExtension())) {
@@ -263,7 +262,7 @@ public class LaunchConfiguration extends PlatformObject implements ILaunchConfig
 
 
 			boolean local = Boolean.parseBoolean(localString);
-			IPath iPath = new Path(path);
+			IPath iPath = IPath.fromOSString(path);
 			String name = getSimpleName(iPath.lastSegment());
 			IContainer container = null;
 			if (!local) {
@@ -454,7 +453,7 @@ public class LaunchConfiguration extends PlatformObject implements ILaunchConfig
 	public IFile getFile() {
 		IContainer container = getContainer();
 		if (container != null) {
-			return container.getFile(new Path(getFileName()));
+			return container.getFile(IPath.fromOSString(getFileName()));
 		}
 		return null;
 	}
@@ -504,7 +503,7 @@ public class LaunchConfiguration extends PlatformObject implements ILaunchConfig
 			if (store != null) {
 				File localFile = store.toLocalFile(EFS.NONE, null);
 				if (localFile != null) {
-					return new Path(localFile.getAbsolutePath());
+					return IPath.fromOSString(localFile.getAbsolutePath());
 				}
 			}
 		} catch (CoreException e) {
@@ -554,7 +553,7 @@ public class LaunchConfiguration extends PlatformObject implements ILaunchConfig
 			} catch (NumberFormatException e) {
 				throw new CoreException(newStatus(DebugCoreMessages.LaunchConfiguration_0, DebugPlugin.ERROR, e));
 			}
-			IPath path = Path.fromPortableString(pathStr);
+			IPath path = IPath.fromPortableString(pathStr);
 			IResource res = null;
 			switch (type) {
 				case IResource.FILE:
@@ -562,7 +561,7 @@ public class LaunchConfiguration extends PlatformObject implements ILaunchConfig
 					break;
 				case IResource.PROJECT:
 					pathStr = path.makeRelative().toPortableString();
-					if(Path.ROOT.isValidSegment(pathStr)) {
+					if (IPath.ROOT.isValidSegment(pathStr)) {
 						res = root.getProject(pathStr);
 					}
 					break;
@@ -592,7 +591,7 @@ public class LaunchConfiguration extends PlatformObject implements ILaunchConfig
 		String lineDelimeter = getLineSeparator();
 		boolean local = true;
 		if (file == null) {
-			relativePath = new Path(getName());
+			relativePath = IPath.fromOSString(getName());
 		} else {
 			local = false;
 			relativePath = file.getFullPath();

--- a/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchConfigurationType.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchConfigurationType.java
@@ -29,7 +29,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugPlugin;
@@ -412,7 +411,7 @@ public class LaunchConfigurationType extends PlatformObject implements ILaunchCo
 	@Override
 	public ILaunchConfigurationWorkingCopy newInstance(IContainer container, String name) throws CoreException {
 		// validate the configuration name - see bug 275741
-		IPath path = new Path(name);
+		IPath path = IPath.fromOSString(name);
 		if (container == null) {
 			// not allowed to nest in sub directory when local
 			if (path.segmentCount() > 1) {

--- a/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchManager.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/LaunchManager.java
@@ -80,7 +80,6 @@ import org.eclipse.core.runtime.ISafeRunnable;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.ListenerList;
 import org.eclipse.core.runtime.MultiStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.core.runtime.SafeRunner;
@@ -2537,7 +2536,7 @@ public class LaunchManager extends PlatformObject implements ILaunchManager, IRe
 				break;
 			}
 			lmonitor.subTask(MessageFormat.format(DebugCoreMessages.LaunchManager_28, new Object[] { source.getName() }));
-			IPath location = new Path(LOCAL_LAUNCH_CONFIGURATION_CONTAINER_PATH.toOSString()).append(source.getName());
+			IPath location = IPath.fromOSString(LOCAL_LAUNCH_CONFIGURATION_CONTAINER_PATH.toOSString()).append(source.getName());
 			File target = location.toFile();
 			IPath locationdir = location.removeLastSegments(1);
 			if(!locationdir.toFile().exists()) {

--- a/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/ResourceFactory.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/ResourceFactory.java
@@ -18,7 +18,7 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.IAdaptable;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 
 /**
  * The ResourceFactory is used to save and recreate an IResource object.
@@ -52,7 +52,7 @@ public class ResourceFactory {
 		if (type == null) {
 			// Old format memento. Create an IResource using findMember.
 			// Will return null for resources in closed projects.
-			res = root.findMember(new Path(fileName));
+			res = root.findMember(IPath.fromOSString(fileName));
 		} else {
 			int resourceType = Integer.parseInt(type);
 
@@ -61,9 +61,9 @@ public class ResourceFactory {
 			} else if (resourceType == IResource.PROJECT) {
 				res = root.getProject(fileName);
 			} else if (resourceType == IResource.FOLDER) {
-				res = root.getFolder(new Path(fileName));
+				res = root.getFolder(IPath.fromOSString(fileName));
 			} else if (resourceType == IResource.FILE) {
-				res = root.getFile(new Path(fileName));
+				res = root.getFile(IPath.fromOSString(fileName));
 			}
 		}
 		return res;

--- a/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/SystemVariableResolver.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/SystemVariableResolver.java
@@ -17,7 +17,6 @@ import java.net.URL;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.variables.IDynamicVariable;
 import org.eclipse.core.variables.IDynamicVariableResolver;
@@ -41,7 +40,7 @@ public class SystemVariableResolver implements IDynamicVariableResolver {
 			return Platform.getOSArch();
 		} else if ("ECLIPSE_HOME".equals(argument)) { //$NON-NLS-1$
 			URL installURL = Platform.getInstallLocation().getURL();
-			IPath ppath = new Path(installURL.getFile()).removeTrailingSeparator();
+			IPath ppath = IPath.fromOSString(installURL.getFile()).removeTrailingSeparator();
 			return getCorrectPath(ppath.toOSString());
 		} else if ("NL".equals(argument)) { //$NON-NLS-1$
 			return Platform.getNL();

--- a/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/sourcelookup/containers/ArchiveSourceContainerType.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/sourcelookup/containers/ArchiveSourceContainerType.java
@@ -16,7 +16,7 @@ package org.eclipse.debug.internal.core.sourcelookup.containers;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.debug.core.sourcelookup.ISourceContainer;
 import org.eclipse.debug.core.sourcelookup.containers.AbstractSourceContainerTypeDelegate;
 import org.eclipse.debug.core.sourcelookup.containers.ArchiveSourceContainer;
@@ -44,7 +44,7 @@ public class ArchiveSourceContainerType extends AbstractSourceContainerTypeDeleg
 				}
 				String detect = element.getAttribute("detectRoot"); //$NON-NLS-1$
 				boolean auto = "true".equals(detect); //$NON-NLS-1$
-				IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(string));
+				IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(IPath.fromOSString(string));
 				return new ArchiveSourceContainer(file, auto);
 			}
 			abort(SourceLookupMessages.ExternalArchiveSourceContainerType_11, null);

--- a/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/sourcelookup/containers/DirectorySourceContainerType.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/sourcelookup/containers/DirectorySourceContainerType.java
@@ -14,7 +14,7 @@
 package org.eclipse.debug.internal.core.sourcelookup.containers;
 
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.debug.core.sourcelookup.ISourceContainer;
 import org.eclipse.debug.core.sourcelookup.containers.AbstractSourceContainerTypeDelegate;
 import org.eclipse.debug.core.sourcelookup.containers.DirectorySourceContainer;
@@ -42,7 +42,7 @@ public class DirectorySourceContainerType extends AbstractSourceContainerTypeDel
 				}
 				String nest = element.getAttribute("nest"); //$NON-NLS-1$
 				boolean nested = "true".equals(nest); //$NON-NLS-1$
-				return new DirectorySourceContainer(new Path(string), nested);
+				return new DirectorySourceContainer(IPath.fromOSString(string), nested);
 			}
 			abort(SourceLookupMessages.DirectorySourceContainerType_11, null);
 		}

--- a/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/sourcelookup/containers/FolderSourceContainerType.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/sourcelookup/containers/FolderSourceContainerType.java
@@ -17,7 +17,7 @@ import org.eclipse.core.resources.IFolder;
 import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.debug.core.sourcelookup.ISourceContainer;
 import org.eclipse.debug.core.sourcelookup.containers.AbstractSourceContainerTypeDelegate;
 import org.eclipse.debug.core.sourcelookup.containers.FolderSourceContainer;
@@ -61,7 +61,7 @@ public class FolderSourceContainerType extends AbstractSourceContainerTypeDelega
 				String nest = element.getAttribute("nest"); //$NON-NLS-1$
 				boolean nested = "true".equals(nest); //$NON-NLS-1$
 				IWorkspace workspace = ResourcesPlugin.getWorkspace();
-				IFolder folder = workspace.getRoot().getFolder(new Path(string));
+				IFolder folder = workspace.getRoot().getFolder(IPath.fromOSString(string));
 				return new FolderSourceContainer(folder, nested);
 			}
 			abort(SourceLookupMessages.FolderSourceContainerType_11, null);

--- a/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/variables/ResourceResolver.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/variables/ResourceResolver.java
@@ -24,7 +24,6 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.variables.IDynamicVariable;
 import org.eclipse.core.variables.IDynamicVariableResolver;
@@ -46,7 +45,7 @@ public class ResourceResolver implements IDynamicVariableResolver {
 		if (argument == null) {
 			resource = getSelectedResource(variable);
 		} else {
-			resource = getWorkspaceRoot().findMember(new Path(argument));
+			resource = getWorkspaceRoot().findMember(IPath.fromOSString(argument));
 		}
 		if (resource != null && resource.exists()) {
 			resource = translateSelectedResource(resource);
@@ -125,7 +124,7 @@ public class ResourceResolver implements IDynamicVariableResolver {
 		IStringVariableManager manager = VariablesPlugin.getDefault().getStringVariableManager();
 		try {
 			String pathString = manager.performStringSubstitution("${selected_resource_path}"); //$NON-NLS-1$
-			return ResourcesPlugin.getWorkspace().getRoot().findMember(new Path(pathString));
+			return ResourcesPlugin.getWorkspace().getRoot().findMember(IPath.fromOSString(pathString));
 		} catch (CoreException e) {
 			// unable to resolve a selection
 		}

--- a/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/variables/WorkspaceResolver.java
+++ b/org.eclipse.debug.core/core/org/eclipse/debug/internal/core/variables/WorkspaceResolver.java
@@ -22,8 +22,8 @@ import org.eclipse.core.resources.IResourceStatus;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.variables.IDynamicVariable;
 import org.eclipse.core.variables.IDynamicVariableResolver;
@@ -45,7 +45,7 @@ public final class WorkspaceResolver implements IDynamicVariableResolver {
 		if (argument == null) {
 			resource = root;
 		} else {
-			resource = root.findMember(new Path(argument));
+			resource = root.findMember(IPath.fromOSString(argument));
 		}
 
 		if (resource != null && resource.exists()) {

--- a/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/midi/launcher/MidiLaunchDelegate.java
+++ b/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/midi/launcher/MidiLaunchDelegate.java
@@ -29,7 +29,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.ILaunch;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -82,7 +81,7 @@ public class MidiLaunchDelegate extends LaunchConfigurationDelegate {
 			abort("MIDI file not specified.", null); //$NON-NLS-1$
 		}
 		IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-		IFile file = root.getFile(new Path(fileName));
+		IFile file = root.getFile(IPath.fromOSString(fileName));
 		if (!file.exists()) {
 			abort("MIDI file does not exist.", null); //$NON-NLS-1$
 		}

--- a/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/launcher/PDALaunchDelegate.java
+++ b/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/launcher/PDALaunchDelegate.java
@@ -25,9 +25,9 @@ import java.util.List;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunch;
@@ -68,7 +68,7 @@ public class PDALaunchDelegate extends LaunchConfigurationDelegate {
 		commandList.add(javaVMExec);
 
 		commandList.add("-cp"); //$NON-NLS-1$
-		commandList.add(File.pathSeparator + DebugCorePlugin.getFileInPlugin(new Path("bin"))); //$NON-NLS-1$
+		commandList.add(File.pathSeparator + DebugCorePlugin.getFileInPlugin(IPath.fromOSString("bin"))); //$NON-NLS-1$
 
 		commandList.add("org.eclipse.debug.examples.pdavm.PDAVirtualMachine"); //$NON-NLS-1$
 
@@ -78,7 +78,7 @@ public class PDALaunchDelegate extends LaunchConfigurationDelegate {
 			abort("Perl program unspecified.", null); //$NON-NLS-1$
 		}
 
-		IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(new Path(program));
+		IFile file = ResourcesPlugin.getWorkspace().getRoot().getFile(IPath.fromOSString(program));
 		if (!file.exists()) {
 			abort(MessageFormat.format("Perl program {0} does not exist.", new Object[] { file.getFullPath().toString() }), null); //$NON-NLS-1$
 		}

--- a/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/model/PDADebugTarget.java
+++ b/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/model/PDADebugTarget.java
@@ -34,7 +34,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.DebugEvent;
@@ -246,7 +245,7 @@ public class PDADebugTarget extends PDADebugElement implements IDebugTarget, IBr
 						}
 					}
 					if (resource != null) {
-						IPath p = new Path(program);
+						IPath p = IPath.fromOSString(program);
 						return resource.getFullPath().equals(p);
 					}
 				}

--- a/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/protocol/PDAFrameData.java
+++ b/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/protocol/PDAFrameData.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.StringTokenizer;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 
 /**
  * Object representing a frame in the stack command results.
@@ -37,7 +36,7 @@ public class PDAFrameData {
 	PDAFrameData(String frameString) {
 		StringTokenizer st = new StringTokenizer(frameString, "|"); //$NON-NLS-1$
 
-		fFilePath = new Path(st.nextToken());
+		fFilePath = IPath.fromOSString(st.nextToken());
 		fPC = Integer.parseInt(st.nextToken());
 		fFunction = st.nextToken();
 

--- a/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/sourcelookup/PDASourcePathComputerDelegate.java
+++ b/org.eclipse.debug.examples.core/src/org/eclipse/debug/examples/core/pda/sourcelookup/PDASourcePathComputerDelegate.java
@@ -19,8 +19,8 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.sourcelookup.ISourceContainer;
 import org.eclipse.debug.core.sourcelookup.ISourcePathComputerDelegate;
@@ -43,7 +43,7 @@ public class PDASourcePathComputerDelegate implements ISourcePathComputerDelegat
 		String path = configuration.getAttribute(DebugCorePlugin.ATTR_PDA_PROGRAM, (String)null);
 		ISourceContainer sourceContainer = null;
 		if (path != null) {
-			IResource resource = ResourcesPlugin.getWorkspace().getRoot().findMember(new Path(path));
+			IResource resource = ResourcesPlugin.getWorkspace().getRoot().findMember(IPath.fromOSString(path));
 			if (resource != null) {
 				//#ifdef ex4
 //#				// TODO: Exercise 4 - seed the source lookup path

--- a/org.eclipse.debug.examples.memory/META-INF/MANIFEST.MF
+++ b/org.eclipse.debug.examples.memory/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Export-Package: org.eclipse.debug.examples.internal.memory;x-internal:=true,
  org.eclipse.debug.examples.internal.memory.launchconfig;x-internal:=true
 Require-Bundle: org.eclipse.core.expressions,
  org.eclipse.ui,
- org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.debug.core;bundle-version="3.9.0",
  org.eclipse.debug.ui;bundle-version="3.10.0",
  org.eclipse.core.resources,

--- a/org.eclipse.debug.examples.memory/src/org/eclipse/debug/examples/internal/memory/MemoryViewSamplePlugin.java
+++ b/org.eclipse.debug.examples.memory/src/org/eclipse/debug/examples/internal/memory/MemoryViewSamplePlugin.java
@@ -18,7 +18,7 @@ import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
@@ -124,7 +124,7 @@ public class MemoryViewSamplePlugin extends AbstractUIPlugin {
 		Bundle bundle = Platform.getBundle(PLUGIN_ID);
 		URL url = null;
 		if (bundle != null) {
-			url = FileLocator.find(bundle, new Path(path), null);
+			url = FileLocator.find(bundle, IPath.fromOSString(path), null);
 			if (url != null) {
 				desc = ImageDescriptor.createFromURL(url);
 			}

--- a/org.eclipse.debug.examples.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.debug.examples.ui/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.debug.examples.ui;singleton:=true
-Bundle-Version: 1.8.0.qualifier
+Bundle-Version: 1.8.100.qualifier
 Bundle-Activator: org.eclipse.debug.examples.ui.pda.DebugUIPlugin
 Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",
  org.eclipse.core.resources,

--- a/org.eclipse.debug.examples.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.debug.examples.ui/META-INF/MANIFEST.MF
@@ -4,7 +4,7 @@ Bundle-Name: %Bundle-Name
 Bundle-SymbolicName: org.eclipse.debug.examples.ui;singleton:=true
 Bundle-Version: 1.8.100.qualifier
 Bundle-Activator: org.eclipse.debug.examples.ui.pda.DebugUIPlugin
-Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",
+Require-Bundle: org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.resources,
  org.eclipse.debug.core;bundle-version="3.9.0",
  org.eclipse.ui,

--- a/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/midi/launcher/MidiMainTab.java
+++ b/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/midi/launcher/MidiMainTab.java
@@ -19,7 +19,6 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.examples.core.midi.launcher.MidiLaunchDelegate;
@@ -183,7 +182,7 @@ public class MidiMainTab extends AbstractLaunchConfigurationTab {
 		}
 		IResource[] resources = null;
 		if (file!= null) {
-			IPath path = new Path(file);
+			IPath path = IPath.fromOSString(file);
 			IResource res = ResourcesPlugin.getWorkspace().getRoot().findMember(path);
 			if (res != null) {
 				resources = new IResource[]{res};
@@ -215,7 +214,7 @@ public class MidiMainTab extends AbstractLaunchConfigurationTab {
 		setMessage(null);
 		String text = fFileText.getText();
 		if (text.length() > 0) {
-			IPath path = new Path(text);
+			IPath path = IPath.fromOSString(text);
 			if (ResourcesPlugin.getWorkspace().getRoot().findMember(path) == null) {
 				setErrorMessage("File does not exist"); //$NON-NLS-1$
 				return false;

--- a/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/DebugUIPlugin.java
+++ b/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/DebugUIPlugin.java
@@ -23,7 +23,7 @@ import java.util.MissingResourceException;
 import java.util.ResourceBundle;
 
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.resource.ImageRegistry;
@@ -185,7 +185,7 @@ public class DebugUIPlugin extends AbstractUIPlugin {
 		Bundle bundle = Platform.getBundle(PLUGIN_ID);
 		URL url = null;
 		if (bundle != null) {
-			url = FileLocator.find(bundle, new Path(path), null);
+			url = FileLocator.find(bundle, IPath.fromOSString(path), null);
 			if (url != null) {
 				desc = ImageDescriptor.createFromURL(url);
 			}

--- a/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/launcher/PDAMainTab.java
+++ b/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/launcher/PDAMainTab.java
@@ -21,7 +21,6 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.examples.core.pda.DebugCorePlugin;
@@ -148,7 +147,7 @@ public class PDAMainTab extends AbstractLaunchConfigurationTab {
 		// perform resource mapping for contextual launch
 		IResource[] resources = null;
 		if (program!= null) {
-			IPath path = new Path(program);
+			IPath path = IPath.fromOSString(program);
 			IResource res = ResourcesPlugin.getWorkspace().getRoot().findMember(path);
 			if (res != null) {
 				resources = new IResource[]{res};
@@ -173,7 +172,7 @@ public class PDAMainTab extends AbstractLaunchConfigurationTab {
 //#		//	empty, providing the user with feedback.
 		//#else
 		if (text.length() > 0) {
-			IPath path = new Path(text);
+			IPath path = IPath.fromOSString(text);
 			IResource member = ResourcesPlugin.getWorkspace().getRoot().findMember(path);
 			if (member == null) {
 				setErrorMessage("Specified program does not exist"); //$NON-NLS-1$

--- a/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/presentation/PDAModelPresentation.java
+++ b/org.eclipse.debug.examples.ui/src/org/eclipse/debug/examples/ui/pda/presentation/PDAModelPresentation.java
@@ -17,7 +17,6 @@ package org.eclipse.debug.examples.ui.pda.presentation;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.DebugException;
 import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.debug.core.model.ILineBreakpoint;
@@ -87,7 +86,7 @@ public class PDAModelPresentation extends LabelProvider implements IDebugModelPr
 		try {
 			String pgmPath = target.getLaunch().getLaunchConfiguration().getAttribute(DebugCorePlugin.ATTR_PDA_PROGRAM, (String)null);
 			if (pgmPath != null) {
-				IPath path = new Path(pgmPath);
+				IPath path = IPath.fromOSString(pgmPath);
 				String label = ""; //$NON-NLS-1$
 				if (target.isTerminated()) {
 					label = "<terminated>"; //$NON-NLS-1$

--- a/org.eclipse.debug.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.debug.tests/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: org.eclipse.debug.tests;singleton:=true
 Bundle-Version: 3.13.200.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="[3.6.0,4.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.debug.ui;bundle-version="[3.10.0,4.0.0)",
  org.junit,
  org.eclipse.core.filesystem;bundle-version="[1.3.0,2.0.0)",

--- a/org.eclipse.debug.tests/META-INF/MANIFEST.MF
+++ b/org.eclipse.debug.tests/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.debug.tests;singleton:=true
-Bundle-Version: 3.13.1.qualifier
+Bundle-Version: 3.13.200.qualifier
 Bundle-Localization: plugin
 Require-Bundle: org.eclipse.ui;bundle-version="[3.6.0,4.0.0)",
  org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",

--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/ArgumentParsingTests.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/ArgumentParsingTests.java
@@ -26,7 +26,7 @@ import java.util.Arrays;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.URIUtil;
 import org.eclipse.debug.core.DebugPlugin;
@@ -87,7 +87,7 @@ public class ArgumentParsingTests extends AbstractDebugTest {
 		File classPathFile = URIUtil.toFile(URIUtil.toURI(classPathUrl));
 
 		String[] execArgs= new String[arguments.length + 4];
-		execArgs[0] = new Path(System.getProperty("java.home")).append("bin/java").toOSString(); //$NON-NLS-1$ //$NON-NLS-2$
+		execArgs[0] = IPath.fromOSString(System.getProperty("java.home")).append("bin/java").toOSString(); //$NON-NLS-1$ //$NON-NLS-2$
 		execArgs[1] = "-cp"; //$NON-NLS-1$
 		execArgs[2]= classPathFile.getAbsolutePath();
 		execArgs[3]= ArgumentsPrinter.class.getName();

--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/DebugFileStore.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/DebugFileStore.java
@@ -32,7 +32,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 
 /**
@@ -65,7 +64,7 @@ public class DebugFileStore extends FileStore {
 		List<String> children = new ArrayList<>();
 		IPath me = getPath();
 		for (URI id : uris) {
-			Path path = new Path(id.getPath());
+			IPath path = IPath.fromOSString(id.getPath());
 			if (path.segmentCount() > 0) {
 				if (path.removeLastSegments(1).equals(me)) {
 					children.add(path.lastSegment());
@@ -115,7 +114,7 @@ public class DebugFileStore extends FileStore {
 
 	private IPath getPath() {
 		URI me = toURI();
-		IPath path = new Path(me.getPath());
+		IPath path = IPath.fromOSString(me.getPath());
 		return path;
 	}
 

--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/DebugFileSystem.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/DebugFileSystem.java
@@ -20,7 +20,7 @@ import java.util.Map;
 
 import org.eclipse.core.filesystem.IFileStore;
 import org.eclipse.core.filesystem.provider.FileSystem;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 
 /**
  * A simple in memory file system to test launch configurations in EFS
@@ -46,7 +46,7 @@ public class DebugFileSystem extends FileSystem {
 		system = this;
 		// create root of the file system
 		try {
-			setContents(new URI("debug", Path.ROOT.toString(), null), DIRECTORY_BYTES); //$NON-NLS-1$
+			setContents(new URI("debug", IPath.ROOT.toString(), null), DIRECTORY_BYTES); //$NON-NLS-1$
 		} catch (URISyntaxException e) {}
 	}
 

--- a/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
+++ b/org.eclipse.debug.tests/src/org/eclipse/debug/tests/launching/LaunchConfigurationTests.java
@@ -54,7 +54,6 @@ import org.eclipse.core.resources.ProjectScope;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.preferences.IEclipsePreferences;
 import org.eclipse.core.runtime.preferences.InstanceScope;
@@ -1131,7 +1130,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 
 		// create folder in EFS
 		IFolder folder = getProject().getFolder("efs"); //$NON-NLS-1$
-		folder.createLink(new URI("debug", Path.ROOT.toString(), null), 0, null); //$NON-NLS-1$
+		folder.createLink(new URI("debug", IPath.ROOT.toString(), null), 0, null); //$NON-NLS-1$
 
 		// create configuration
 		ILaunchConfigurationWorkingCopy wc = newConfiguration(folder, "efsConfig"); //$NON-NLS-1$
@@ -1166,7 +1165,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 
 		// create folder in EFS
 		IFolder folder = getProject().getFolder("efs2"); //$NON-NLS-1$
-		folder.createLink(new URI("debug", Path.ROOT.toString(), null), 0, null); //$NON-NLS-1$
+		folder.createLink(new URI("debug", IPath.ROOT.toString(), null), 0, null); //$NON-NLS-1$
 
 		// create configuration
 		ILaunchConfigurationWorkingCopy wc = newConfiguration(folder, "efsConfig"); //$NON-NLS-1$
@@ -1205,7 +1204,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 
 		// create folder in EFS
 		IFolder folder = project.getFolder("efs2"); //$NON-NLS-1$
-		folder.createLink(new URI("debug", Path.ROOT.toString(), null), 0, null); //$NON-NLS-1$
+		folder.createLink(new URI("debug", IPath.ROOT.toString(), null), 0, null); //$NON-NLS-1$
 
 		// create configuration
 		ILaunchConfigurationWorkingCopy wc = newConfiguration(folder, "efsConfig"); //$NON-NLS-1$
@@ -1229,7 +1228,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 		// get the new handle
 		project = ResourcesPlugin.getWorkspace().getRoot().getProject("SFEemaneR"); //$NON-NLS-1$
 		assertTrue("Project should exist", project.exists()); //$NON-NLS-1$
-		IFile file = project.getFile(new Path("efs2/efsConfig.launch")); //$NON-NLS-1$
+		IFile file = project.getFile(IPath.fromOSString("efs2/efsConfig.launch")); //$NON-NLS-1$
 		assertTrue("launch config file should exist", file.exists()); //$NON-NLS-1$
 		handle = getLaunchManager().getLaunchConfiguration(file);
 		assertTrue("launch config should exist", handle.exists()); //$NON-NLS-1$
@@ -1261,7 +1260,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 		ILaunchConfiguration handle = wc.doSave();
 		assertTrue("Configuration should exist", handle.exists()); //$NON-NLS-1$
 
-		File dir = TestsPlugin.getFileInPlugin(new Path("test-import")); //$NON-NLS-1$
+		File dir = TestsPlugin.getFileInPlugin(IPath.fromOSString("test-import")); //$NON-NLS-1$
 		assertTrue("Import directory does not exist", dir.exists()); //$NON-NLS-1$
 		LaunchManager manager = (LaunchManager) getLaunchManager();
 
@@ -1560,7 +1559,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	@Test
 	public void testIllegalFileSepCharName() {
 		try {
-			newConfiguration(null, new Path("some").append("nested").append("config").toOSString()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			newConfiguration(null, IPath.fromOSString("some").append("nested").append("config").toOSString()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		} catch (CoreException e) {
 			// i.e. expected code path
 			return;
@@ -1578,7 +1577,7 @@ public class LaunchConfigurationTests extends AbstractLaunchTest implements ILau
 	@Test
 	public void testLegalFileSepCharName() {
 		try {
-			newConfiguration(getProject(), new Path("some").append("nested").append("config").toOSString()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
+			newConfiguration(getProject(), IPath.fromOSString("some").append("nested").append("config").toOSString()); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$
 		} catch (CoreException e) {
 			assertTrue("Should *not* be an illegal argument - can nest shared cofigurations", false); //$NON-NLS-1$
 		}

--- a/org.eclipse.debug.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.debug.ui/META-INF/MANIFEST.MF
@@ -88,7 +88,7 @@ Require-Bundle: org.eclipse.core.variables;bundle-version="[3.2.800,4.0.0)",
  org.eclipse.ui.workbench.texteditor;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui.ide;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui.editors;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.26.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.filesystem;bundle-version="[1.2.0,2.0.0)",
  org.eclipse.e4.ui.services;bundle-version="[1.3.700,2.0.0)"
 Bundle-ActivationPolicy: lazy

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugPluginImages.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugPluginImages.java
@@ -23,7 +23,7 @@ package org.eclipse.debug.internal.ui;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
 import org.eclipse.core.runtime.IExtensionPoint;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.debug.internal.core.IConfigurationElementConstants;
 import org.eclipse.debug.ui.IDebugUIConstants;
@@ -296,7 +296,8 @@ public class DebugPluginImages {
 			imageRegistry.put(key, ImageDescriptor.getMissingImageDescriptor());
 		} else {
 			imageRegistry.put(key,
-					ImageDescriptor.createFromURLSupplier(true, () -> FileLocator.find(bundle, new Path(path), null)));
+					ImageDescriptor.createFromURLSupplier(true,
+							() -> FileLocator.find(bundle, IPath.fromOSString(path), null)));
 		}
 	}
 

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPlugin.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/DebugUIPlugin.java
@@ -38,9 +38,9 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IConfigurationElement;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.SubMonitor;
@@ -1362,7 +1362,7 @@ public class DebugUIPlugin extends AbstractUIPlugin implements ILaunchListener, 
 		if (iconPath != null) {
 			Bundle bundle = Platform.getBundle(element.getContributor().getName());
 			return ImageDescriptor.createFromURLSupplier(true, () -> {
-				URL iconURL = FileLocator.find(bundle, new Path(iconPath), null);
+				URL iconURL = FileLocator.find(bundle, IPath.fromOSString(iconPath), null);
 				if (iconURL != null) {
 					return iconURL;
 				} else { // try to search as a URL in case it is absolute path
@@ -1390,7 +1390,8 @@ public class DebugUIPlugin extends AbstractUIPlugin implements ILaunchListener, 
 	public static ImageDescriptor getImageDescriptor(String bundleName, String path) {
 		if (path != null) {
 			Bundle bundle = Platform.getBundle(bundleName);
-			return ImageDescriptor.createFromURLSupplier(true, () -> FileLocator.find(bundle, new Path(path), null));
+			return ImageDescriptor.createFromURLSupplier(true,
+					() -> FileLocator.find(bundle, IPath.fromOSString(path), null));
 		}
 		return null;
 	}

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/groups/CommonTabLite.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/groups/CommonTabLite.java
@@ -29,7 +29,6 @@ import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchConfigurationWorkingCopy;
 import org.eclipse.debug.internal.core.IInternalDebugCoreConstants;
@@ -259,7 +258,7 @@ class CommonTabLite extends AbstractLaunchConfigurationTab {
 	 * @return the container for the specified path or null if one cannot be determined
 	 */
 	private IContainer getContainer(String path) {
-		Path containerPath = new Path(path);
+		IPath containerPath = IPath.fromOSString(path);
 		return (IContainer) getWorkspaceRoot().findMember(containerPath);
 	}
 

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/importexport/breakpoints/WizardExportBreakpointsPage.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/importexport/breakpoints/WizardExportBreakpointsPage.java
@@ -21,7 +21,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.model.IBreakpoint;
 import org.eclipse.debug.internal.core.IInternalDebugCoreConstants;
@@ -151,7 +150,7 @@ public class WizardExportBreakpointsPage extends WizardPage implements Listener 
 		dialog.setText(ImportExportMessages.WizardExportBreakpoints_0);
 		String file = dialog.open();
 		if(file != null) {
-			IPath path = new Path(file);
+			IPath path = IPath.fromOSString(file);
 			if (path != null) {
 				setErrorMessage(null);
 				if(path.getFileExtension() == null) {
@@ -221,7 +220,7 @@ public class WizardExportBreakpointsPage extends WizardPage implements Listener 
 			setErrorMessage(ImportExportMessages.WizardExportBreakpointsPage_0);
 			return false;
 		}
-		IPath path = new Path(filepath);
+		IPath path = IPath.fromOSString(filepath);
 		if(!path.removeLastSegments(1).toFile().exists()) {
 			setErrorMessage(ImportExportMessages.WizardExportBreakpointsPage_3);
 			return false;
@@ -286,7 +285,7 @@ public class WizardExportBreakpointsPage extends WizardPage implements Listener 
 	 */
 	public boolean finish() {
 		try {
-			IPath path = new Path(fDestinationNameField.getText().trim());
+			IPath path = IPath.fromOSString(fDestinationNameField.getText().trim());
 			if(path.getFileExtension() == null) {
 				path = path.addFileExtension(IImportExportConstants.EXTENSION);
 			}

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/importexport/launchconfigurations/ExportLaunchConfigurationsWizardPage.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/importexport/launchconfigurations/ExportLaunchConfigurationsWizardPage.java
@@ -34,7 +34,6 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.MultiStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.debug.core.DebugPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -278,7 +277,7 @@ public class ExportLaunchConfigurationsWizardPage extends WizardPage {
 				dd.setText(WizardMessages.ExportLaunchConfigurationsWizard_0);
 				String file = dd.open();
 				if(file != null) {
-					IPath path = new Path(file);
+					IPath path = IPath.fromOSString(file);
 					if (path != null) {
 						fFilePath.setText(path.toString());
 						setPageComplete(isComplete());
@@ -339,7 +338,7 @@ public class ExportLaunchConfigurationsWizardPage extends WizardPage {
 			@Override
 			public IStatus runInUIThread(IProgressMonitor monitor) {
 				IProgressMonitor progressMonitor = monitor != null ? monitor : new NullProgressMonitor();
-				IPath destpath = new Path(dpath);
+				IPath destpath = IPath.fromOSString(dpath);
 				File destfolder = destpath.toFile();
 				if(!destfolder.exists()) {
 					destfolder.mkdirs();

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/importexport/launchconfigurations/ImportLaunchConfigurationsWizardPage.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/importexport/launchconfigurations/ImportLaunchConfigurationsWizardPage.java
@@ -23,7 +23,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
 import org.eclipse.debug.core.DebugPlugin;
@@ -110,7 +109,7 @@ public class ImportLaunchConfigurationsWizardPage extends WizardResourceImportPa
 			DebugFileSystemElement newelement = null;
 			for (File child : allchildren) {
 				if(child.isFile()) {
-					Path childpath = new Path(child.getAbsolutePath());
+					IPath childpath = IPath.fromOSString(child.getAbsolutePath());
 					String extension = childpath.getFileExtension();
 					if (extension != null && (extension.equals(ILaunchConfiguration.LAUNCH_CONFIGURATION_FILE_EXTENSION) || extension.equals(ILaunchConfiguration.LAUNCH_CONFIGURATION_PROTOTYPE_FILE_EXTENSION))) {
 						newelement = new DebugFileSystemElement(provider.getLabel(child), this, provider.isFolder(child));
@@ -151,7 +150,7 @@ public class ImportLaunchConfigurationsWizardPage extends WizardResourceImportPa
 		String oldpath = settings.get(OLD_PATH);
 		oldpath = (oldpath == null ? IInternalDebugCoreConstants.EMPTY_STRING : oldpath);
 		fFromDirectory.setText((oldpath == null ? IInternalDebugCoreConstants.EMPTY_STRING : oldpath));
-		resetSelection(new Path(oldpath));
+		resetSelection(IPath.fromOSString(oldpath));
 		setControl(comp);
 		PlatformUI.getWorkbench().getHelpSystem().setHelp(comp, IDebugHelpContextIds.IMPORT_LAUNCH_CONFIGURATIONS_PAGE);
 		setPageComplete(false);
@@ -173,7 +172,8 @@ public class ImportLaunchConfigurationsWizardPage extends WizardResourceImportPa
 		final List<File> filesToImport = new ArrayList<>();
 		for (Object resource :  getSelectedResources()) {
 			config = (File) ((DebugFileSystemElement) resource).getFileSystemObject();
-			newconfig = new File(new Path(LaunchManager.LOCAL_LAUNCH_CONFIGURATION_CONTAINER_PATH.toOSString()).append(config.getName()).toOSString());
+			newconfig = new File(
+					LaunchManager.LOCAL_LAUNCH_CONFIGURATION_CONTAINER_PATH.append(config.getName()).toOSString());
 			if(newconfig.exists() && !overwrite) {
 				if(nowall) {
 					continue;
@@ -276,7 +276,7 @@ public class ImportLaunchConfigurationsWizardPage extends WizardResourceImportPa
 				dd.setText(WizardMessages.ImportLaunchConfigurationsWizardPage_0);
 				String filename = dd.open();
 				if(filename != null) {
-					IPath path = new Path(filename);
+					IPath path = IPath.fromOSString(filename);
 					if (path != null) {
 						fFromDirectory.setText(path.toString());
 						resetSelection(path);

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/quickaccess/LaunchQuickAccessElement.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/quickaccess/LaunchQuickAccessElement.java
@@ -15,7 +15,7 @@ package org.eclipse.debug.internal.ui.quickaccess;
 
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.FileLocator;
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.debug.core.ILaunchConfiguration;
 import org.eclipse.debug.core.ILaunchMode;
 import org.eclipse.debug.internal.ui.DebugPluginImages;
@@ -57,7 +57,8 @@ public class LaunchQuickAccessElement extends QuickAccessElement {
 			REGISTRY.put(key, ImageDescriptor.getMissingImageDescriptor());
 		} else {
 			REGISTRY.put(key,
-					ImageDescriptor.createFromURLSupplier(true, () -> FileLocator.find(bundle, new Path(path), null)));
+					ImageDescriptor.createFromURLSupplier(true,
+							() -> FileLocator.find(bundle, IPath.fromOSString(path), null)));
 		}
 	}
 

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/sourcelookup/SourceContainerWorkbenchAdapter.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/sourcelookup/SourceContainerWorkbenchAdapter.java
@@ -16,7 +16,6 @@ package org.eclipse.debug.internal.ui.sourcelookup;
 import java.io.File;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.sourcelookup.containers.ArchiveSourceContainer;
 import org.eclipse.debug.core.sourcelookup.containers.DirectorySourceContainer;
 import org.eclipse.debug.core.sourcelookup.containers.ExternalArchiveSourceContainer;
@@ -44,7 +43,7 @@ public class SourceContainerWorkbenchAdapter implements IWorkbenchAdapter {
 		if (o instanceof DirectorySourceContainer) {
 			DirectorySourceContainer container = (DirectorySourceContainer) o;
 			File file = container.getDirectory();
-			IPath path = new Path(file.getAbsolutePath());
+			IPath path = IPath.fromOSString(file.getAbsolutePath());
 			return SourceElementWorkbenchAdapter.getQualifiedName(path);
 		}
 		if (o instanceof FolderSourceContainer) {
@@ -57,7 +56,7 @@ public class SourceContainerWorkbenchAdapter implements IWorkbenchAdapter {
 		}
 		if (o instanceof ExternalArchiveSourceContainer) {
 			ExternalArchiveSourceContainer container = (ExternalArchiveSourceContainer)o;
-			IPath path = new Path(container.getName());
+			IPath path = IPath.fromOSString(container.getName());
 			return SourceElementWorkbenchAdapter.getQualifiedName(path);
 		}
 		return IInternalDebugCoreConstants.EMPTY_STRING;

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/sourcelookup/browsers/DirectorySourceContainerBrowser.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/sourcelookup/browsers/DirectorySourceContainerBrowser.java
@@ -14,7 +14,7 @@
  *******************************************************************************/
 package org.eclipse.debug.internal.ui.sourcelookup.browsers;
 
-import org.eclipse.core.runtime.Path;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.debug.core.sourcelookup.ISourceContainer;
 import org.eclipse.debug.core.sourcelookup.ISourceLookupDirector;
 import org.eclipse.debug.core.sourcelookup.containers.DirectorySourceContainer;
@@ -35,7 +35,8 @@ public class DirectorySourceContainerBrowser extends AbstractSourceContainerBrow
 		if (dialog.open() == Window.OK) {
 			String directory = dialog.getDirectory();
 			if(directory !=null) {
-				containers[0] = new DirectorySourceContainer(new Path(directory), dialog.isSearchSubfolders());
+				containers[0] = new DirectorySourceContainer(IPath.fromOSString(directory),
+						dialog.isSearchSubfolders());
 				return containers;
 			}
 		}
@@ -56,7 +57,8 @@ public class DirectorySourceContainerBrowser extends AbstractSourceContainerBrow
 				String directory = dialog.getDirectory();
 				if(directory !=null) {
 					containers[0].dispose();
-					return new ISourceContainer[]{ new DirectorySourceContainer(new Path(directory), dialog.isSearchSubfolders())};
+					return new ISourceContainer[] {
+							new DirectorySourceContainer(IPath.fromOSString(directory), dialog.isSearchSubfolders()) };
 				}
 			}
 		}

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/sourcelookup/browsers/ExternalArchiveSourceContainerBrowser.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/sourcelookup/browsers/ExternalArchiveSourceContainerBrowser.java
@@ -14,7 +14,6 @@
 package org.eclipse.debug.internal.ui.sourcelookup.browsers;
 
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.debug.core.sourcelookup.ISourceContainer;
 import org.eclipse.debug.core.sourcelookup.ISourceLookupDirector;
 import org.eclipse.debug.core.sourcelookup.containers.ExternalArchiveSourceContainer;
@@ -52,7 +51,7 @@ public class ExternalArchiveSourceContainerBrowser extends AbstractSourceContain
 		int nChosen= fileNames.length;
 		if (nChosen > 0) {
 			rootDir = dialog.getFilterPath();
-			IPath filterPath= new Path(rootDir);
+			IPath filterPath = IPath.fromOSString(rootDir);
 			ISourceContainer[] containers= new ISourceContainer[nChosen];
 			for (int i= 0; i < nChosen; i++) {
 				IPath path= filterPath.append(fileNames[i]).makeAbsolute();

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ProcessConsole.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/internal/ui/views/console/ProcessConsole.java
@@ -43,10 +43,10 @@ import org.eclipse.core.resources.IWorkspace;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.PlatformObject;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.runtime.jobs.Job;
@@ -181,7 +181,7 @@ public class ProcessConsole extends IOConsole implements IConsole, IDebugEventSe
 		if (file != null && configuration != null) {
 			IWorkspace workspace = ResourcesPlugin.getWorkspace();
 			IWorkspaceRoot root = workspace.getRoot();
-			Path path = new Path(file);
+			IPath path = IPath.fromOSString(file);
 			IFile ifile = root.getFileForLocation(path);
 			String message = null;
 
@@ -1005,7 +1005,7 @@ public class ProcessConsole extends IOConsole implements IConsole, IDebugEventSe
 		@Override
 		public void linkActivated() {
 			IEditorInput input;
-			Path path = new Path(fFilePath);
+			IPath path = IPath.fromOSString(fFilePath);
 			IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 			IFile ifile = root.getFileForLocation(path);
 			if (ifile == null) { // The file is not in the workspace

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/CommonTab.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/CommonTab.java
@@ -35,7 +35,6 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.variables.VariablesPlugin;
@@ -621,7 +620,7 @@ public class CommonTab extends AbstractLaunchConfigurationTab {
 	 * @return the container for the specified path or null if one cannot be determined
 	 */
 	private IContainer getContainer(String path) {
-		Path containerPath = new Path(path);
+		IPath containerPath = IPath.fromOSString(path);
 		return (IContainer) getWorkspaceRoot().findMember(containerPath);
 	}
 

--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/WorkingDirectoryBlock.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/WorkingDirectoryBlock.java
@@ -27,7 +27,6 @@ import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.Assert;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.variables.IStringVariableManager;
 import org.eclipse.core.variables.VariablesPlugin;
 import org.eclipse.debug.core.ILaunchConfiguration;
@@ -237,7 +236,7 @@ public abstract class WorkingDirectoryBlock extends AbstractLaunchConfigurationT
 				IStringVariableManager manager = VariablesPlugin.getDefault().getStringVariableManager();
 				try {
 					path = manager.performStringSubstitution(path, false);
-					IPath uriPath = new Path(path).makeAbsolute();
+					IPath uriPath = IPath.fromOSString(path).makeAbsolute();
 					IContainer[] containers = root.findContainersForLocationURI(URIUtil.toURI(uriPath));
 					if (containers.length > 0) {
 						res = containers[0];

--- a/org.eclipse.ui.externaltools/External Tools Base/org/eclipse/ui/externaltools/internal/variables/BuildProjectResolver.java
+++ b/org.eclipse.ui.externaltools/External Tools Base/org/eclipse/ui/externaltools/internal/variables/BuildProjectResolver.java
@@ -18,8 +18,8 @@ import org.eclipse.core.externaltools.internal.model.ExternalToolBuilder;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.IStatus;
-import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Status;
 import org.eclipse.core.variables.IDynamicVariable;
 import org.eclipse.core.variables.IDynamicVariableResolver;
@@ -33,7 +33,7 @@ public class BuildProjectResolver implements IDynamicVariableResolver {
 	public String resolveValue(IDynamicVariable variable, String argument) throws CoreException {
 		IResource resource= ExternalToolBuilder.getBuildProject();
 		if (argument != null && resource != null) {
-			resource = ((IProject)resource).findMember(new Path(argument));
+			resource = ((IProject) resource).findMember(IPath.fromOSString(argument));
 		}
 		if (resource != null && resource.exists()) {
 			return resource.getLocation().toOSString();

--- a/org.eclipse.ui.externaltools/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.externaltools/META-INF/MANIFEST.MF
@@ -16,7 +16,7 @@ Require-Bundle: org.eclipse.ui.ide;bundle-version="[3.2.0,4.0.0)";resolution:=op
  org.eclipse.core.variables;bundle-version="[3.2.800,4.0.0)",
  org.eclipse.ui;bundle-version="[3.2.0,4.0.0)",
  org.eclipse.debug.ui;bundle-version="[3.10.0,4.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.1.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.core.externaltools;bundle-version="[1.0.300,2.0.0)"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.ui.externaltools/META-INF/MANIFEST.MF
+++ b/org.eclipse.ui.externaltools/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: %Plugin.name
 Bundle-SymbolicName: org.eclipse.ui.externaltools; singleton:=true
-Bundle-Version: 3.6.0.qualifier
+Bundle-Version: 3.6.100.qualifier
 Bundle-Activator: org.eclipse.ui.externaltools.internal.model.ExternalToolsPlugin
 Bundle-Vendor: %Plugin.providerName
 Bundle-Localization: plugin

--- a/org.eclipse.unittest.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.unittest.ui/META-INF/MANIFEST.MF
@@ -16,6 +16,6 @@ Require-Bundle:
  org.eclipse.jface.text;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.ui;bundle-version="[3.5.0,4.0.0)",
  org.eclipse.debug.ui;bundle-version="[3.5.0,4.0.0)",
- org.eclipse.core.runtime;bundle-version="[3.11.0,4.0.0)",
+ org.eclipse.core.runtime;bundle-version="[3.27.0,4.0.0)",
  org.eclipse.compare;bundle-version="[3.5.0,4.0.0)"
 Bundle-RequiredExecutionEnvironment: JavaSE-17

--- a/org.eclipse.unittest.ui/META-INF/MANIFEST.MF
+++ b/org.eclipse.unittest.ui/META-INF/MANIFEST.MF
@@ -3,7 +3,7 @@ Automatic-Module-Name: org.eclipse.unittest.ui
 Bundle-ManifestVersion: 2
 Bundle-Name: %pluginName
 Bundle-SymbolicName: org.eclipse.unittest.ui;singleton:=true
-Bundle-Version: 1.1.0.qualifier
+Bundle-Version: 1.1.100.qualifier
 Bundle-Activator: org.eclipse.unittest.internal.UnitTestPlugin
 Bundle-ActivationPolicy: lazy
 Bundle-Vendor: %providerName

--- a/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/Images.java
+++ b/org.eclipse.unittest.ui/src/org/eclipse/unittest/internal/ui/Images.java
@@ -20,7 +20,6 @@ import org.eclipse.swt.graphics.Image;
 
 import org.eclipse.core.runtime.FileLocator;
 import org.eclipse.core.runtime.IPath;
-import org.eclipse.core.runtime.Path;
 
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.resource.ImageDescriptor;
@@ -30,7 +29,7 @@ import org.eclipse.jface.resource.ImageDescriptor;
  */
 public class Images {
 
-	private static final IPath ICONS_PATH = new Path("$nl$/icons/full"); //$NON-NLS-1$
+	private static final IPath ICONS_PATH = IPath.fromOSString("$nl$/icons/full"); //$NON-NLS-1$
 
 	/**
 	 * Create an {@link ImageDescriptor} from a given path


### PR DESCRIPTION
Use the new IPath factory methods introduced in https://github.com/eclipse-equinox/equinox/pull/228 in P2.

With this PR `org.eclipse.core.runtime.Path` is not referenced anymore in Platform-Debug's entire code base.