### PR TITLE
Show launches of shortcuts below the launches dialog in the popup

### DIFF
--- a/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/ContextualLaunchAction.java
+++ b/org.eclipse.debug.ui/ui/org/eclipse/debug/ui/actions/ContextualLaunchAction.java
@@ -16,8 +16,10 @@ package org.eclipse.debug.ui.actions;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 
 import org.eclipse.core.expressions.Expression;
 import org.eclipse.core.expressions.IEvaluationContext;
@@ -231,6 +233,7 @@ public abstract class ContextualLaunchAction implements IObjectActionDelegate, I
 			 new MenuItem(menu, SWT.SEPARATOR);
 		}
 		List<String> categories = new ArrayList<>();
+		Map<LaunchShortcutExtension, ILaunchConfiguration[]> launchConfigurations = new LinkedHashMap<>();
 		for(LaunchShortcutExtension ext : filteredShortCuts) {
 			for(String mode : ext.getModes()) {
 				if (mode.equals(fMode)) {
@@ -244,9 +247,7 @@ public abstract class ContextualLaunchAction implements IObjectActionDelegate, I
 						ext.getLaunchConfigurations(editor) :
 						ext.getLaunchConfigurations(ss);
 					if (configurations != null) {
-						for (ILaunchConfiguration configuration : configurations) {
-							populateMenuItem(mode, ext, menu, configuration, accelerator++, "   "); //$NON-NLS-1$
-						}
+						launchConfigurations.put(ext, configurations);
 					}
 				}
 			}
@@ -276,6 +277,12 @@ public abstract class ContextualLaunchAction implements IObjectActionDelegate, I
 					ActionContributionItem item= new ActionContributionItem(action);
 					item.fill(menu, -1);
 				}
+			}
+		}
+		// now add collected launches
+		for (Entry<LaunchShortcutExtension, ILaunchConfiguration[]> entry : launchConfigurations.entrySet()) {
+			for (ILaunchConfiguration configuration : entry.getValue()) {
+				populateMenuItem(fMode, entry.getKey(), menu, configuration, accelerator++, null);
 			}
 		}
 


### PR DESCRIPTION
Currently provided launches are shown below their providers with a little pseudo indentation using some space what has some drawbacks

- it looks a bit misplaced an not as an indentation
- it breaks the order of accelerators once a new config is added
- run configs are not shortcuts even though shortcuts often create a launch

This is now changed to put them below the "Launchconfigurations ..." menu item where they better fit semantically and also keep the original accelerator order intact.

## This is how it looks before:
![grafik](https://github.com/eclipse-platform/eclipse.platform.debug/assets/1331477/9d6ac766-929a-4d68-b07c-3db2b075d8b3)

## This is how it looks after this change:
![grafik](https://github.com/eclipse-platform/eclipse.platform.debug/assets/1331477/fe584f8f-96b1-4c8e-a855-10cae2ca04e0)
